### PR TITLE
chore: document reasoning behind using an AST for code gen

### DIFF
--- a/doc/adr/0003-generate-code-from-a-specialized-ast.md
+++ b/doc/adr/0003-generate-code-from-a-specialized-ast.md
@@ -12,8 +12,8 @@ A goal of the `awscdk-service-spec` project is to generate code from the service
 that will allow consumers to describe model resources in any jsii language.
 The generated code must be well-typed, jsii compatible and human readable.
 
-Writing formatted code blocks is a solved problem. [^code-block-writer] [^codemaker] [^json2jsii]\
-Existing code generation projects within the AWS CDK context mix specification parsing and analysis with code writing and do not generally distinguish between the two.
+Emitting formatted code blocks is a solved problem. [^code-block-writer] [^codemaker] [^json2jsii]\
+Existing code generation projects within the AWS CDK context handle model interpretation and code emitting in the same step.
 This design has proven itself challenging in regards of extensibility.
  [^cdk-cloudformation] [^cfn2ts]
 


### PR DESCRIPTION
[Rendered ADR](https://github.com/cdklabs/awscdk-service-spec/pull/26/files?short_path=61cdf01#diff-61cdf01deef5a59672d877e216df2c7f08fd76d17cbc3a963ea0a1e27c2e70a5)