### PR TITLE
chore: make type objects more consistent

### DIFF
--- a/packages/@aws-cdk/service-spec-build/src/cloudformation-registry.ts
+++ b/packages/@aws-cdk/service-spec-build/src/cloudformation-registry.ts
@@ -61,7 +61,7 @@ export function loadCloudFormationRegistryResource(db: SpecDatabase, region: Reg
 
       switch (resolved.schema.type) {
         case 'string':
-          return 'string';
+          return { type: 'string' };
 
         case 'array':
           // FIXME: insertionOrder, uniqueItems
@@ -70,14 +70,14 @@ export function loadCloudFormationRegistryResource(db: SpecDatabase, region: Reg
             element => ({ type: 'array', element }));
 
         case 'boolean':
-          return 'boolean';
+          return { type: 'boolean' };
 
         case 'object':
           return schemaObjectToModelType(nameHint, resolved.schema, fail);
 
         case 'number':
         case 'integer':
-          return 'number';
+          return { type: 'number' };
       }
     });
   }
@@ -101,7 +101,7 @@ export function loadCloudFormationRegistryResource(db: SpecDatabase, region: Reg
       } else {
         // Fully untyped map
         // FIXME: is 'json' really a primitive type, or do we mean `Map<unknown>` ?
-        return 'json';
+        return { type: 'json' };
       }
     }
 

--- a/packages/@aws-cdk/service-spec/src/types/resource.ts
+++ b/packages/@aws-cdk/service-spec/src/types/resource.ts
@@ -63,7 +63,22 @@ Invariants.push(evolutionInvariant<Property>(
 
 export type PropertyType = PrimitiveType | DefinitionReference | ArrayType<PropertyType> | MapType<PropertyType>;
 
-export type PrimitiveType = 'string' | 'number' | 'boolean' | 'json';
+export type PrimitiveType = StringType | NumberType | BooleanType | JsonType;
+
+export interface StringType {
+  readonly type: 'string';
+}
+
+export interface NumberType {
+  readonly type: 'number';
+}
+
+export interface BooleanType {
+  readonly type: 'boolean';
+}
+export interface JsonType {
+  readonly type: 'json';
+}
 
 export interface DefinitionReference {
   readonly type: 'ref';


### PR DESCRIPTION
Turn `'string'` into `{ type: 'string' }`, to make it easier to type test in a `switch` statement.
