### PR TITLE
chore: switch `build:pull_request_target` back to `pull_request`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,8 @@
 
 name: build
 on:
+  pull_request: {}
   workflow_dispatch: {}
-  pull_request_target: {}
   merge_group:
     branches:
       - main

--- a/projenrc/merge-queue.ts
+++ b/projenrc/merge-queue.ts
@@ -1,4 +1,4 @@
-import { javascript, Component, JsonPatch } from 'projen';
+import { javascript, Component } from 'projen';
 import { AutoMerge, AutoMergeOptions } from './auto-merge';
 
 /**
@@ -31,9 +31,7 @@ export class MergeQueue extends Component {
     }
 
     const buildWorkflow = project.github?.tryFindWorkflow('build');
-    buildWorkflow?.file?.patch(JsonPatch.remove('/on/pull_request'));
     buildWorkflow?.on({
-      pullRequestTarget: {},
       mergeGroup: {
         branches: ['main'],
       },


### PR DESCRIPTION
The PR that enables LFS now fails to build, because the workflow on `main` still has `lfs: false`.
