### PR TITLE
chore: move to current ts-jest config

### DIFF
--- a/packages/@aws-cdk/cfn-resources/package.json
+++ b/packages/@aws-cdk/cfn-resources/package.json
@@ -79,10 +79,14 @@
       ]
     ],
     "preset": "ts-jest",
-    "globals": {
-      "ts-jest": {
-        "tsconfig": "tsconfig.dev.json"
-      }
+    "globals": {},
+    "transform": {
+      "^.+\\.tsx?$": [
+        "ts-jest",
+        {
+          "tsconfig": "tsconfig.dev.json"
+        }
+      ]
     }
   },
   "types": "lib/index.d.ts",

--- a/packages/@aws-cdk/service-spec-build/package.json
+++ b/packages/@aws-cdk/service-spec-build/package.json
@@ -78,10 +78,14 @@
       ]
     ],
     "preset": "ts-jest",
-    "globals": {
-      "ts-jest": {
-        "tsconfig": "tsconfig.dev.json"
-      }
+    "globals": {},
+    "transform": {
+      "^.+\\.tsx?$": [
+        "ts-jest",
+        {
+          "tsconfig": "tsconfig.dev.json"
+        }
+      ]
     }
   },
   "types": "lib/index.d.ts",

--- a/packages/@aws-cdk/service-spec-sources/package.json
+++ b/packages/@aws-cdk/service-spec-sources/package.json
@@ -81,10 +81,14 @@
       ]
     ],
     "preset": "ts-jest",
-    "globals": {
-      "ts-jest": {
-        "tsconfig": "tsconfig.dev.json"
-      }
+    "globals": {},
+    "transform": {
+      "^.+\\.tsx?$": [
+        "ts-jest",
+        {
+          "tsconfig": "tsconfig.dev.json"
+        }
+      ]
     }
   },
   "types": "lib/index.d.ts",

--- a/packages/@aws-cdk/service-spec/package.json
+++ b/packages/@aws-cdk/service-spec/package.json
@@ -74,10 +74,14 @@
       ]
     ],
     "preset": "ts-jest",
-    "globals": {
-      "ts-jest": {
-        "tsconfig": "tsconfig.dev.json"
-      }
+    "globals": {},
+    "transform": {
+      "^.+\\.tsx?$": [
+        "ts-jest",
+        {
+          "tsconfig": "tsconfig.dev.json"
+        }
+      ]
     }
   },
   "types": "lib/index.d.ts",

--- a/packages/@cdklabs/tskb/package.json
+++ b/packages/@cdklabs/tskb/package.json
@@ -71,10 +71,14 @@
       ]
     ],
     "preset": "ts-jest",
-    "globals": {
-      "ts-jest": {
-        "tsconfig": "tsconfig.dev.json"
-      }
+    "globals": {},
+    "transform": {
+      "^.+\\.tsx?$": [
+        "ts-jest",
+        {
+          "tsconfig": "tsconfig.dev.json"
+        }
+      ]
     }
   },
   "types": "lib/index.d.ts",

--- a/packages/@cdklabs/typewriter/package.json
+++ b/packages/@cdklabs/typewriter/package.json
@@ -74,10 +74,14 @@
       ]
     ],
     "preset": "ts-jest",
-    "globals": {
-      "ts-jest": {
-        "tsconfig": "tsconfig.dev.json"
-      }
+    "globals": {},
+    "transform": {
+      "^.+\\.tsx?$": [
+        "ts-jest",
+        {
+          "tsconfig": "tsconfig.dev.json"
+        }
+      ]
     }
   },
   "types": "lib/index.d.ts",

--- a/projenrc/monorepo.ts
+++ b/projenrc/monorepo.ts
@@ -277,6 +277,19 @@ export class MonorepoTypeScriptProject extends pj.typescript.TypeScriptProject {
 
     this.parent = props.parent;
 
+    // jest config
+    if (this.jest?.config && this.jest.config.preset === 'ts-jest') {
+      delete this.jest.config.globals?.['ts-jest'];
+      this.jest.config.transform = {
+        '^.+\\.tsx?$': [
+          'ts-jest',
+          {
+            tsconfig: this.tsconfigDev.fileName,
+          },
+        ],
+      };
+    }
+
     // Tasks
     this.tasks.tryFind('default')?.reset('(cd `git rev-parse --show-toplevel`; npx projen default)');
     this.tasks.removeTask('clobber');


### PR DESCRIPTION
Fixes deprecation warning thrown by `ts-jest`.

This is tricky to fix in projen since the correct config is dependent on the used version of `ts-jest`.
Within this repo the version is known and more constraint.