### PR TITLE
fix: add `arrayType`

### DIFF
--- a/packages/@aws-cdk/service-spec-sources/schemas/CloudFormationRegistryResource.schema.json
+++ b/packages/@aws-cdk/service-spec-sources/schemas/CloudFormationRegistryResource.schema.json
@@ -754,6 +754,14 @@
         "$comment": {
           "type": "string"
         },
+        "arrayType": {
+          "description": "Does this array describe full reality?\n\n- If `Standard`, real elements must be exactly equal to the given array.\n- If `AttributeList`, the real array may be a superset of the given array.",
+          "enum": [
+            "AttributeList",
+            "Standard"
+          ],
+          "type": "string"
+        },
         "default": {
           "items": {},
           "type": "array"
@@ -766,7 +774,7 @@
           "type": "array"
         },
         "insertionOrder": {
-          "description": "Whether to treat the order as significant\n\nIn other words, does this array model a \"sequence\" or a \"set\".\n\n- `true` (default): order is significant, the array is a sequence.\n- `false`: order is insignificant, the array is a set.",
+          "description": "Whether to treat the order as significant\n\nIn other words, does this array model a \"sequence\" or a \"multiset\".\n\n- `true` (default): order is significant, the array is a sequence.\n- `false`: order is insignificant, the array is a set.",
           "type": "boolean"
         },
         "items": {

--- a/packages/@aws-cdk/service-spec-sources/src/loading/patches/field-witnesses.ts
+++ b/packages/@aws-cdk/service-spec-sources/src/loading/patches/field-witnesses.ts
@@ -60,6 +60,7 @@ export const ARRAY_KEY_WITNESS: TypeKeyWitness<jsonschema.SchemaArray> = {
   minItems: true,
   title: true,
   uniqueItems: true,
+  arrayType: true,
 };
 
 export const BOOLEAN_KEY_WITNESS: TypeKeyWitness<jsonschema.Boolean> = {

--- a/packages/@aws-cdk/service-spec-sources/src/types/registry-schema/JsonSchema.ts
+++ b/packages/@aws-cdk/service-spec-sources/src/types/registry-schema/JsonSchema.ts
@@ -133,7 +133,7 @@ export namespace jsonschema {
     /**
      * Whether to treat the order as significant
      *
-     * In other words, does this array model a "sequence" or a "set".
+     * In other words, does this array model a "sequence" or a "multiset".
      *
      * - `true` (default): order is significant, the array is a sequence.
      * - `false`: order is insignificant, the array is a set.
@@ -151,6 +151,16 @@ export namespace jsonschema {
     // readonly minLength?: number;
     readonly default?: any[];
     readonly examples?: any[];
+
+    /**
+     * Does this array describe full reality?
+     *
+     * - If `Standard`, real elements must be exactly equal to the given array.
+     * - If `AttributeList`, the real array may be a superset of the given array.
+     *
+     * @see https://github.com/aws-cloudformation/cloudformation-resource-schema#arraytype
+     */
+    readonly arrayType?: 'AttributeList' | 'Standard';
   }
 
   export interface Boolean extends Annotatable {


### PR DESCRIPTION
`arrayType` is a legitimate keyword for array types, added by CloudFormation themselves.

Fixes #