### PR TITLE
fix(cfn-resource): namespaces not exported

### DIFF
--- a/packages/@aws-cdk/cfn-resources/test/__snapshots__/resources.test.ts.snap
+++ b/packages/@aws-cdk/cfn-resources/test/__snapshots__/resources.test.ts.snap
@@ -200,7 +200,7 @@ export class CfnRestApi extends cdk.CfnResource implements cdk.IInspectable, cdk
   }
 }
 
-namespace CfnRestApi {
+export namespace CfnRestApi {
   /**
    * \`S3Location\` is a property of the [AWS::ApiGateway::RestApi](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html) resource that specifies the Amazon S3 location of a OpenAPI (formerly Swagger) file that defines a set of RESTful APIs in JSON or YAML.
    *
@@ -761,7 +761,7 @@ export class CfnRole extends cdk.CfnResource implements cdk.IInspectable, cdk.IT
   }
 }
 
-namespace CfnRole {
+export namespace CfnRole {
   /**
    * Contains information about an attached policy.
    *
@@ -1273,7 +1273,7 @@ export class CfnFunction extends cdk.CfnResource implements cdk.IInspectable, cd
   }
 }
 
-namespace CfnFunction {
+export namespace CfnFunction {
   /**
    * The function's [AWS X-Ray](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html) tracing configuration. To sample and record incoming requests, set \`Mode\` to \`Active\` .
    *
@@ -2488,7 +2488,7 @@ export class CfnBucket extends cdk.CfnResource implements cdk.IInspectable, cdk.
   }
 }
 
-namespace CfnBucket {
+export namespace CfnBucket {
   /**
    * Configures the transfer acceleration state for an Amazon S3 bucket.
    *
@@ -7929,7 +7929,7 @@ export class CfnSkill extends cdk.CfnResource implements cdk.IInspectable {
   }
 }
 
-namespace CfnSkill {
+export namespace CfnSkill {
   /**
    * The \`AuthenticationConfiguration\` property type specifies the Login with Amazon (LWA) configuration used to authenticate with the Alexa service.
    *

--- a/packages/@aws-cdk/cfn-resources/test/__snapshots__/services.test.ts.snap
+++ b/packages/@aws-cdk/cfn-resources/test/__snapshots__/services.test.ts.snap
@@ -108,7 +108,7 @@ export class CfnSkill extends cdk.CfnResource implements cdk.IInspectable {
   }
 }
 
-namespace CfnSkill {
+export namespace CfnSkill {
   /**
    * The \`AuthenticationConfiguration\` property type specifies the Login with Amazon (LWA) configuration used to authenticate with the Alexa service.
    *
@@ -907,7 +907,7 @@ export class CfnSchedule extends cdk.CfnResource implements cdk.IInspectable {
   }
 }
 
-namespace CfnSchedule {
+export namespace CfnSchedule {
   /**
    * Allows you to configure a time window during which EventBridge Scheduler invokes the schedule.
    *

--- a/packages/@cdklabs/typewriter/src/class.ts
+++ b/packages/@cdklabs/typewriter/src/class.ts
@@ -11,7 +11,6 @@ import { TypeDeclaration, TypeSpec } from './type-declaration';
 import { Initializer, InitializerSpec } from './type-member';
 
 export interface ClassSpec extends TypeSpec {
-  export?: boolean;
   properties?: PropertySpec[];
   abstract?: boolean;
   extends?: Type;

--- a/packages/@cdklabs/typewriter/src/interface.ts
+++ b/packages/@cdklabs/typewriter/src/interface.ts
@@ -6,7 +6,6 @@ import { Type } from './type';
 import { TypeSpec } from './type-declaration';
 
 export interface InterfaceSpec extends TypeSpec {
-  export?: boolean;
   properties?: PropertySpec[];
   extends?: Type[];
 }

--- a/packages/@cdklabs/typewriter/src/struct.ts
+++ b/packages/@cdklabs/typewriter/src/struct.ts
@@ -3,10 +3,9 @@ import { MemberType } from './member-type';
 import { Property, PropertySpec } from './property';
 import { IScope } from './scope';
 import { SymbolKind } from './symbol';
-import { TypeDeclaration } from './type-declaration';
+import { Exportable, TypeDeclaration } from './type-declaration';
 
-export interface StructSpec extends Omit<jsii.InterfaceType, 'assembly' | 'fqn' | 'kind' | 'properties'> {
-  export?: boolean;
+export interface StructSpec extends Omit<jsii.InterfaceType, 'assembly' | 'fqn' | 'kind' | 'properties'>, Exportable {
   properties?: PropertySpec[];
 }
 

--- a/packages/@cdklabs/typewriter/src/type-declaration.ts
+++ b/packages/@cdklabs/typewriter/src/type-declaration.ts
@@ -4,9 +4,11 @@ import { IScope } from './scope';
 import { ThingSymbol, SymbolKind } from './symbol';
 import { Type } from './type';
 
-export interface TypeSpec extends Omit<jsii.TypeBase, 'assembly' | 'fqn' | 'kind'> {
-  exported?: boolean;
+export interface Exportable {
+  export?: boolean;
 }
+
+export interface TypeSpec extends Omit<jsii.TypeBase, 'assembly' | 'fqn' | 'kind'>, Exportable {}
 
 /**
  * An abstract jsii type
@@ -39,7 +41,7 @@ export abstract class TypeDeclaration implements Documented {
    * Whether this type is being exported from its scope
    */
   public get exported() {
-    return !!this.spec.exported;
+    return !!this.spec.export;
   }
 
   public readonly type: Type;


### PR DESCRIPTION
This was caused by using different names `export` vs `exported` in the spec.
Pulled it out into a shared interface to avoid future confusion.