### PR TITLE
fix(cfn-resources): kinesis metrics don't compile

### DIFF
--- a/packages/@aws-cdk/cfn-resources/src/cli/cdk/canned-metrics.ts
+++ b/packages/@aws-cdk/cfn-resources/src/cli/cdk/canned-metrics.ts
@@ -59,12 +59,12 @@ export class MetricsClass extends ClassType {
 
     this.returnType = new InterfaceType(this.scope, {
       name: 'MetricWithDims',
+      export: true,
       properties: [
         {
           name: 'namespace',
           type: Type.STRING,
           immutable: true,
-          optional: true,
         },
         {
           name: 'metricName',
@@ -98,7 +98,7 @@ export class MetricsClass extends ClassType {
     }
 
     // If we have more than one dimension set, add a generic declaration
-    if (dimensionSets.length >= 1) {
+    if (dimensionSets.length > 1) {
       this.addMetricMethodDeclaration(name, Type.ANY);
     }
 

--- a/packages/@aws-cdk/cfn-resources/test/__snapshots__/resources.test.ts.snap
+++ b/packages/@aws-cdk/cfn-resources/test/__snapshots__/resources.test.ts.snap
@@ -111,8 +111,8 @@ export class ApiGatewayMetrics {
   }
 }
 
-interface MetricWithDims<D> {
-  readonly namespace?: string;
+export interface MetricWithDims<D> {
+  readonly namespace: string;
 
   readonly metricName: string;
 
@@ -1494,8 +1494,8 @@ export class LambdaMetrics {
   }
 }
 
-interface MetricWithDims<D> {
-  readonly namespace?: string;
+export interface MetricWithDims<D> {
+  readonly namespace: string;
 
   readonly metricName: string;
 
@@ -2704,9 +2704,7 @@ exports[`AWS::S3::Bucket 1`] = `
   "augmentations": undefined,
   "metrics": "/* eslint-disable prettier/prettier,max-len */
 export class S3Metrics {
-  public static bucketSizeBytesAverage(dimensions: { BucketName: string; StorageType: string; }): MetricWithDims<{ BucketName: string; StorageType: string; }>;
-
-  public static bucketSizeBytesAverage(dimensions: any): MetricWithDims<any> {
+  public static bucketSizeBytesAverage(dimensions: { BucketName: string; StorageType: string; }): MetricWithDims<{ BucketName: string; StorageType: string; }> {
     return {
       "namespace": "AWS/S3",
       "metricName": "BucketSizeBytes",
@@ -2715,9 +2713,7 @@ export class S3Metrics {
     };
   }
 
-  public static numberOfObjectsAverage(dimensions: { BucketName: string; StorageType: string; }): MetricWithDims<{ BucketName: string; StorageType: string; }>;
-
-  public static numberOfObjectsAverage(dimensions: any): MetricWithDims<any> {
+  public static numberOfObjectsAverage(dimensions: { BucketName: string; StorageType: string; }): MetricWithDims<{ BucketName: string; StorageType: string; }> {
     return {
       "namespace": "AWS/S3",
       "metricName": "NumberOfObjects",
@@ -2727,8 +2723,8 @@ export class S3Metrics {
   }
 }
 
-interface MetricWithDims<D> {
-  readonly namespace?: string;
+export interface MetricWithDims<D> {
+  readonly namespace: string;
 
   readonly metricName: string;
 
@@ -8057,9 +8053,7 @@ QueueBase.prototype.metricSentMessageSize = function(props?: cw.MetricOptions) {
 };",
   "metrics": "/* eslint-disable prettier/prettier,max-len */
 export class SQSMetrics {
-  public static numberOfMessagesSentAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }>;
-
-  public static numberOfMessagesSentAverage(dimensions: any): MetricWithDims<any> {
+  public static numberOfMessagesSentAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }> {
     return {
       "namespace": "AWS/SQS",
       "metricName": "NumberOfMessagesSent",
@@ -8068,9 +8062,7 @@ export class SQSMetrics {
     };
   }
 
-  public static approximateNumberOfMessagesDelayedAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }>;
-
-  public static approximateNumberOfMessagesDelayedAverage(dimensions: any): MetricWithDims<any> {
+  public static approximateNumberOfMessagesDelayedAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }> {
     return {
       "namespace": "AWS/SQS",
       "metricName": "ApproximateNumberOfMessagesDelayed",
@@ -8079,9 +8071,7 @@ export class SQSMetrics {
     };
   }
 
-  public static numberOfMessagesReceivedAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }>;
-
-  public static numberOfMessagesReceivedAverage(dimensions: any): MetricWithDims<any> {
+  public static numberOfMessagesReceivedAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }> {
     return {
       "namespace": "AWS/SQS",
       "metricName": "NumberOfMessagesReceived",
@@ -8090,9 +8080,7 @@ export class SQSMetrics {
     };
   }
 
-  public static numberOfMessagesDeletedAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }>;
-
-  public static numberOfMessagesDeletedAverage(dimensions: any): MetricWithDims<any> {
+  public static numberOfMessagesDeletedAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }> {
     return {
       "namespace": "AWS/SQS",
       "metricName": "NumberOfMessagesDeleted",
@@ -8101,9 +8089,7 @@ export class SQSMetrics {
     };
   }
 
-  public static approximateNumberOfMessagesNotVisibleAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }>;
-
-  public static approximateNumberOfMessagesNotVisibleAverage(dimensions: any): MetricWithDims<any> {
+  public static approximateNumberOfMessagesNotVisibleAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }> {
     return {
       "namespace": "AWS/SQS",
       "metricName": "ApproximateNumberOfMessagesNotVisible",
@@ -8112,9 +8098,7 @@ export class SQSMetrics {
     };
   }
 
-  public static approximateNumberOfMessagesVisibleAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }>;
-
-  public static approximateNumberOfMessagesVisibleAverage(dimensions: any): MetricWithDims<any> {
+  public static approximateNumberOfMessagesVisibleAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }> {
     return {
       "namespace": "AWS/SQS",
       "metricName": "ApproximateNumberOfMessagesVisible",
@@ -8123,9 +8107,7 @@ export class SQSMetrics {
     };
   }
 
-  public static approximateAgeOfOldestMessageAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }>;
-
-  public static approximateAgeOfOldestMessageAverage(dimensions: any): MetricWithDims<any> {
+  public static approximateAgeOfOldestMessageAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }> {
     return {
       "namespace": "AWS/SQS",
       "metricName": "ApproximateAgeOfOldestMessage",
@@ -8134,9 +8116,7 @@ export class SQSMetrics {
     };
   }
 
-  public static numberOfEmptyReceivesAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }>;
-
-  public static numberOfEmptyReceivesAverage(dimensions: any): MetricWithDims<any> {
+  public static numberOfEmptyReceivesAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }> {
     return {
       "namespace": "AWS/SQS",
       "metricName": "NumberOfEmptyReceives",
@@ -8145,9 +8125,7 @@ export class SQSMetrics {
     };
   }
 
-  public static sentMessageSizeAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }>;
-
-  public static sentMessageSizeAverage(dimensions: any): MetricWithDims<any> {
+  public static sentMessageSizeAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }> {
     return {
       "namespace": "AWS/SQS",
       "metricName": "SentMessageSize",
@@ -8157,8 +8135,8 @@ export class SQSMetrics {
   }
 }
 
-interface MetricWithDims<D> {
-  readonly namespace?: string;
+export interface MetricWithDims<D> {
+  readonly namespace: string;
 
   readonly metricName: string;
 

--- a/packages/@aws-cdk/cfn-resources/test/__snapshots__/services.test.ts.snap
+++ b/packages/@aws-cdk/cfn-resources/test/__snapshots__/services.test.ts.snap
@@ -2749,9 +2749,7 @@ QueueBase.prototype.metricSentMessageSize = function(props?: cw.MetricOptions) {
 };",
   "metrics": "/* eslint-disable prettier/prettier,max-len */
 export class SQSMetrics {
-  public static numberOfMessagesSentAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }>;
-
-  public static numberOfMessagesSentAverage(dimensions: any): MetricWithDims<any> {
+  public static numberOfMessagesSentAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }> {
     return {
       "namespace": "AWS/SQS",
       "metricName": "NumberOfMessagesSent",
@@ -2760,9 +2758,7 @@ export class SQSMetrics {
     };
   }
 
-  public static approximateNumberOfMessagesDelayedAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }>;
-
-  public static approximateNumberOfMessagesDelayedAverage(dimensions: any): MetricWithDims<any> {
+  public static approximateNumberOfMessagesDelayedAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }> {
     return {
       "namespace": "AWS/SQS",
       "metricName": "ApproximateNumberOfMessagesDelayed",
@@ -2771,9 +2767,7 @@ export class SQSMetrics {
     };
   }
 
-  public static numberOfMessagesReceivedAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }>;
-
-  public static numberOfMessagesReceivedAverage(dimensions: any): MetricWithDims<any> {
+  public static numberOfMessagesReceivedAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }> {
     return {
       "namespace": "AWS/SQS",
       "metricName": "NumberOfMessagesReceived",
@@ -2782,9 +2776,7 @@ export class SQSMetrics {
     };
   }
 
-  public static numberOfMessagesDeletedAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }>;
-
-  public static numberOfMessagesDeletedAverage(dimensions: any): MetricWithDims<any> {
+  public static numberOfMessagesDeletedAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }> {
     return {
       "namespace": "AWS/SQS",
       "metricName": "NumberOfMessagesDeleted",
@@ -2793,9 +2785,7 @@ export class SQSMetrics {
     };
   }
 
-  public static approximateNumberOfMessagesNotVisibleAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }>;
-
-  public static approximateNumberOfMessagesNotVisibleAverage(dimensions: any): MetricWithDims<any> {
+  public static approximateNumberOfMessagesNotVisibleAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }> {
     return {
       "namespace": "AWS/SQS",
       "metricName": "ApproximateNumberOfMessagesNotVisible",
@@ -2804,9 +2794,7 @@ export class SQSMetrics {
     };
   }
 
-  public static approximateNumberOfMessagesVisibleAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }>;
-
-  public static approximateNumberOfMessagesVisibleAverage(dimensions: any): MetricWithDims<any> {
+  public static approximateNumberOfMessagesVisibleAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }> {
     return {
       "namespace": "AWS/SQS",
       "metricName": "ApproximateNumberOfMessagesVisible",
@@ -2815,9 +2803,7 @@ export class SQSMetrics {
     };
   }
 
-  public static approximateAgeOfOldestMessageAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }>;
-
-  public static approximateAgeOfOldestMessageAverage(dimensions: any): MetricWithDims<any> {
+  public static approximateAgeOfOldestMessageAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }> {
     return {
       "namespace": "AWS/SQS",
       "metricName": "ApproximateAgeOfOldestMessage",
@@ -2826,9 +2812,7 @@ export class SQSMetrics {
     };
   }
 
-  public static numberOfEmptyReceivesAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }>;
-
-  public static numberOfEmptyReceivesAverage(dimensions: any): MetricWithDims<any> {
+  public static numberOfEmptyReceivesAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }> {
     return {
       "namespace": "AWS/SQS",
       "metricName": "NumberOfEmptyReceives",
@@ -2837,9 +2821,7 @@ export class SQSMetrics {
     };
   }
 
-  public static sentMessageSizeAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }>;
-
-  public static sentMessageSizeAverage(dimensions: any): MetricWithDims<any> {
+  public static sentMessageSizeAverage(dimensions: { QueueName: string; }): MetricWithDims<{ QueueName: string; }> {
     return {
       "namespace": "AWS/SQS",
       "metricName": "SentMessageSize",
@@ -2849,8 +2831,8 @@ export class SQSMetrics {
   }
 }
 
-interface MetricWithDims<D> {
-  readonly namespace?: string;
+export interface MetricWithDims<D> {
+  readonly namespace: string;
 
   readonly metricName: string;
 


### PR DESCRIPTION
Don't generate generic metric method if only one dimension set is used.
`namespace` is not optional
`MetricWithDims` must be exported since we now always specify it as return type and for usage in `kinesis-fixed-canned-metrics.ts` requires it for type inference.

Fixes #138