### PR TITLE
fix(sources): create-pr step must use PAT to be able to create a PR

### DIFF
--- a/.github/workflows/update-source-cfn-schema.yml
+++ b/.github/workflows/update-source-cfn-schema.yml
@@ -28,6 +28,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@v4
         with:
+          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
             feat(sources): update cfn-schema
 

--- a/.github/workflows/update-source-documentation.yml
+++ b/.github/workflows/update-source-documentation.yml
@@ -35,6 +35,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@v4
         with:
+          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
             feat(sources): update documentation
 

--- a/.github/workflows/update-source-resource-spec.yml
+++ b/.github/workflows/update-source-resource-spec.yml
@@ -28,6 +28,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@v4
         with:
+          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
             feat(sources): update resource-spec
 

--- a/.github/workflows/update-source-sam.yml
+++ b/.github/workflows/update-source-sam.yml
@@ -28,6 +28,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@v4
         with:
+          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
             feat(sources): update sam
 

--- a/.github/workflows/update-source-stateful-resources.yml
+++ b/.github/workflows/update-source-stateful-resources.yml
@@ -28,6 +28,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@v4
         with:
+          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
             feat(sources): update stateful-resources
 

--- a/projenrc/update-sources.ts
+++ b/projenrc/update-sources.ts
@@ -95,6 +95,7 @@ abstract class SourceUpdate extends Component {
           pullRequestTitle: `feat(sources): update ${options.name}`,
           pullRequestDescription: `Updates the ${options.name} source from upstream`,
           workflowName,
+          credentials: project.github.projenCredentials,
           labels: ['auto-approve'],
           baseBranch: 'main',
           branchName: `update-source/${options.name}`,


### PR DESCRIPTION
Fixes failing workflows. Accidentally had dropped using the correct credentials.