### PR TITLE
fix(service-spec-sources): report output is not correct

### DIFF
--- a/packages/@aws-cdk/service-spec-sources/src/canonicalize.d.ts
+++ b/packages/@aws-cdk/service-spec-sources/src/canonicalize.d.ts
@@ -1,5 +1,0 @@
-declare module 'canonicalize' {
-  function canonicalize(x: any): string;
-
-  export = canonicalize;
-}

--- a/packages/@aws-cdk/service-spec-sources/src/patches/json-schema-patches.ts
+++ b/packages/@aws-cdk/service-spec-sources/src/patches/json-schema-patches.ts
@@ -3,7 +3,7 @@
  *
  * We simplify some JSON schema representations to make them easier to work with.
  */
-import canonicalize from 'canonicalize';
+import { default as canonicalize } from 'canonicalize';
 import { retainRelevantKeywords, witnessForType } from '../loading/patching/field-witnesses';
 import { JsonLens, JsonObjectLens, NO_MISTAKE, isRoot } from '../loading/patching/json-lens';
 import { makeCompositePatcher, onlyObjects } from '../loading/patching/patching';
@@ -190,7 +190,7 @@ function deepDedupe<A>(xs: A[]): A[] {
   const seen = new Set<string>();
   for (const x of xs) {
     const json = canonicalize(x);
-    if (!seen.has(json)) {
+    if (json && !seen.has(json)) {
       ret.push(x);
       seen.add(json);
     }

--- a/packages/@aws-cdk/service-spec-sources/test/loading/format-patch-report.test.ts
+++ b/packages/@aws-cdk/service-spec-sources/test/loading/format-patch-report.test.ts
@@ -1,0 +1,161 @@
+import { PatchReport, formatPatchReport } from '../../src/loading/patching/';
+
+const subject = {
+  typeName: 'AWS::Some::Resource',
+  properties: {
+    SiblingProp: 'foobar',
+    AffectedProp: {
+      type: 'string',
+      description: 'some description',
+    },
+  },
+};
+
+test('can report replace operation', () => {
+  const report: PatchReport = {
+    fileName: 'some-file.json',
+    reason: 'Backwards compatibility',
+    subject,
+    path: '/properties/AffectedProp',
+    patch: {
+      op: 'replace',
+      path: '/properties/AffectedProp',
+      value: {
+        type: 'object',
+      },
+    },
+  };
+
+  const print = formatPatchReport(report);
+
+  expect(print).toMatchInlineSnapshot(`
+    "some-file.json
+    --------------------------------
+    /properties/AffectedProp: Backwards compatibility
+        {
+          "properties": {
+            "SiblingProp": "foobar"
+    [-]     "AffectedProp": {"type":"string","description":"some description"}
+    [+]     "AffectedProp": {"type":"object"}
+          }
+        }"
+  `);
+});
+
+test('can report remove operation', () => {
+  const report: PatchReport = {
+    fileName: 'some-file.json',
+    reason: 'Backwards compatibility',
+    subject,
+    path: '/properties/AffectedProp',
+    patch: {
+      op: 'remove',
+      path: '/properties/AffectedProp',
+    },
+  };
+
+  const print = formatPatchReport(report);
+
+  expect(print).toMatchInlineSnapshot(`
+    "some-file.json
+    --------------------------------
+    /properties/AffectedProp: Backwards compatibility
+        {
+          "properties": {
+            "SiblingProp": "foobar"
+    [-]     "AffectedProp": {"type":"string","description":"some description"}
+          }
+        }"
+  `);
+});
+
+test('can report move operation', () => {
+  const report: PatchReport = {
+    fileName: 'some-file.json',
+    reason: 'Backwards compatibility',
+    subject,
+    path: '/properties/AffectedProp',
+    patch: {
+      op: 'move',
+      from: '/properties/AffectedProp',
+      path: '/properties/MovedProp',
+    },
+  };
+
+  const print = formatPatchReport(report);
+
+  expect(print).toMatchInlineSnapshot(`
+    "some-file.json
+    --------------------------------
+    /properties/AffectedProp: Backwards compatibility
+        {
+          "properties": {
+            "SiblingProp": "foobar"
+    [-]     "AffectedProp": {"type":"string","description":"some description"}
+    [+]     "MovedProp": {"type":"string","description":"some description"}
+          }
+        }"
+  `);
+});
+
+test('can report add operation', () => {
+  const report: PatchReport = {
+    fileName: 'some-file.json',
+    reason: 'Backwards compatibility',
+    subject,
+    path: '/properties/NewProp',
+    patch: {
+      op: 'add',
+      path: '/properties/NewProp',
+      value: {
+        type: 'object',
+      },
+    },
+  };
+
+  const print = formatPatchReport(report);
+
+  expect(print).toMatchInlineSnapshot(`
+    "some-file.json
+    --------------------------------
+    /properties/NewProp: Backwards compatibility
+        {
+          "properties": {
+            "SiblingProp": "foobar"
+            "AffectedProp": { ... }
+    [+]     "NewProp": {"type":"object"}
+          }
+        }"
+  `);
+});
+
+test('can report deep add operation', () => {
+  const report: PatchReport = {
+    fileName: 'some-file.json',
+    reason: 'Backwards compatibility',
+    subject,
+    path: '/properties/AffectedProp',
+    patch: {
+      op: 'add',
+      path: '/properties/AffectedProp/foo',
+      value: 'bar',
+    },
+  };
+
+  const print = formatPatchReport(report);
+
+  expect(print).toMatchInlineSnapshot(`
+    "some-file.json
+    --------------------------------
+    /properties/AffectedProp: Backwards compatibility
+        {
+          "properties": {
+            "AffectedProp": {
+              "type": "string"
+              "description": "some description"
+    [+]       "foo": "bar"
+            }
+          }
+        }"
+  `);
+});


### PR DESCRIPTION
The patch report wasn't correct for nested properties.
I tried fixing it, but ended up doing a bigger refactor.
It's mostly simplifying the data structure of `PatchReport` by means of getting rid of the tree of lenses.
The reasoning here is that a JsonPatch is always applied to the root document.
We already make sure to only report the first applied patch.
Therefore it should be enough to format the patch based on the root document.
I might be missing something though.

It ends up with this kind of fix:
![image](https://user-images.githubusercontent.com/379814/233203467-51a475d7-1f1b-4a1b-b654-8a8fc71026cd.png)

As part of this I've added some basic test cases.
Also fixes inconsistent trailing commas (all are now removed).
The `canonicalize` fix was required because with a different tsconfig it would not pass tests.