### PR TITLE
fix(cfn-resources): timestamp properties are not of type Date

### DIFF
--- a/packages/@aws-cdk/cfn-resources/src/cli/cdk/type-converter.ts
+++ b/packages/@aws-cdk/cfn-resources/src/cli/cdk/type-converter.ts
@@ -56,6 +56,8 @@ export class TypeConverter {
         return Type.NUMBER;
       case 'boolean':
         return Type.BOOLEAN;
+      case 'date-time':
+        return Type.DATE_TIME;
       case 'array':
         return Type.arrayOf(this.typeFromSpecType(type.element));
       case 'map':

--- a/packages/@aws-cdk/cfn-resources/src/cli/prop-mapping.ts
+++ b/packages/@aws-cdk/cfn-resources/src/cli/prop-mapping.ts
@@ -99,7 +99,7 @@ export class PropMapping {
           parse: CDK_CORE.helpers.FromCloudFormation.getString,
           validate: CDK_CORE.validateString,
         };
-      case PrimitiveType.Date:
+      case PrimitiveType.DateTime:
         return {
           produce: CDK_CORE.dateToCloudFormation,
           parse: CDK_CORE.helpers.FromCloudFormation.getDate,

--- a/packages/@aws-cdk/cfn-resources/test/__snapshots__/resources.test.ts.snap
+++ b/packages/@aws-cdk/cfn-resources/test/__snapshots__/resources.test.ts.snap
@@ -5958,7 +5958,7 @@ export namespace CfnBucket {
      *
      * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-rule.html#cfn-s3-bucket-rule-expirationdate
      */
-    readonly expirationDate?: string;
+    readonly expirationDate?: Date | cdk.IResolvable;
 
     /**
      * Indicates the number of days after creation when objects are deleted from Amazon S3 and Amazon S3 Glacier.
@@ -6182,7 +6182,7 @@ export namespace CfnBucket {
      *
      * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-transition.html#cfn-s3-bucket-transition-transitiondate
      */
-    readonly transitionDate?: string;
+    readonly transitionDate?: Date | cdk.IResolvable;
 
     /**
      * Indicates the number of days after creation when objects are transitioned to the specified storage class.
@@ -8327,7 +8327,7 @@ function CfnBucketTransitionPropertyValidator(properties: any): cdk.ValidationRe
   }
   errors.collect(cdk.propertyValidator("storageClass", cdk.requiredValidator)(properties.storageClass));
   errors.collect(cdk.propertyValidator("storageClass", cdk.validateString)(properties.storageClass));
-  errors.collect(cdk.propertyValidator("transitionDate", cdk.validateString)(properties.transitionDate));
+  errors.collect(cdk.propertyValidator("transitionDate", cdk.validateDate)(properties.transitionDate));
   errors.collect(cdk.propertyValidator("transitionInDays", cdk.validateNumber)(properties.transitionInDays));
   return errors.wrap("supplied properties not correct for \\"TransitionProperty\\"");
 }
@@ -8338,7 +8338,7 @@ function convertCfnBucketTransitionPropertyToCloudFormation(properties: any): an
   CfnBucketTransitionPropertyValidator(properties).assertSuccess();
   return {
     "StorageClass": cdk.stringToCloudFormation(properties.storageClass),
-    "TransitionDate": cdk.stringToCloudFormation(properties.transitionDate),
+    "TransitionDate": cdk.dateToCloudFormation(properties.transitionDate),
     "TransitionInDays": cdk.numberToCloudFormation(properties.transitionInDays)
   };
 }
@@ -8354,7 +8354,7 @@ function CfnBucketTransitionPropertyFromCloudFormation(properties: any): cfn_par
   }
   const ret = new cfn_parse.FromCloudFormationPropertyObject<CfnBucket.TransitionProperty>();
   ret.addPropertyResult("storageClass", "StorageClass", (properties.StorageClass != null ? cfn_parse.FromCloudFormation.getString(properties.StorageClass) : undefined));
-  ret.addPropertyResult("transitionDate", "TransitionDate", (properties.TransitionDate != null ? cfn_parse.FromCloudFormation.getString(properties.TransitionDate) : undefined));
+  ret.addPropertyResult("transitionDate", "TransitionDate", (properties.TransitionDate != null ? cfn_parse.FromCloudFormation.getDate(properties.TransitionDate) : undefined));
   ret.addPropertyResult("transitionInDays", "TransitionInDays", (properties.TransitionInDays != null ? cfn_parse.FromCloudFormation.getNumber(properties.TransitionInDays) : undefined));
   ret.addUnrecognizedPropertiesAsExtra(properties);
   return ret;
@@ -8375,7 +8375,7 @@ function CfnBucketRulePropertyValidator(properties: any): cdk.ValidationResult {
     errors.collect(new cdk.ValidationResult("Expected an object, but received: " + JSON.stringify(properties)));
   }
   errors.collect(cdk.propertyValidator("abortIncompleteMultipartUpload", CfnBucketAbortIncompleteMultipartUploadPropertyValidator)(properties.abortIncompleteMultipartUpload));
-  errors.collect(cdk.propertyValidator("expirationDate", cdk.validateString)(properties.expirationDate));
+  errors.collect(cdk.propertyValidator("expirationDate", cdk.validateDate)(properties.expirationDate));
   errors.collect(cdk.propertyValidator("expirationInDays", cdk.validateNumber)(properties.expirationInDays));
   errors.collect(cdk.propertyValidator("expiredObjectDeleteMarker", cdk.validateBoolean)(properties.expiredObjectDeleteMarker));
   errors.collect(cdk.propertyValidator("id", cdk.validateString)(properties.id));
@@ -8400,7 +8400,7 @@ function convertCfnBucketRulePropertyToCloudFormation(properties: any): any {
   CfnBucketRulePropertyValidator(properties).assertSuccess();
   return {
     "AbortIncompleteMultipartUpload": convertCfnBucketAbortIncompleteMultipartUploadPropertyToCloudFormation(properties.abortIncompleteMultipartUpload),
-    "ExpirationDate": cdk.stringToCloudFormation(properties.expirationDate),
+    "ExpirationDate": cdk.dateToCloudFormation(properties.expirationDate),
     "ExpirationInDays": cdk.numberToCloudFormation(properties.expirationInDays),
     "ExpiredObjectDeleteMarker": cdk.booleanToCloudFormation(properties.expiredObjectDeleteMarker),
     "Id": cdk.stringToCloudFormation(properties.id),
@@ -8429,7 +8429,7 @@ function CfnBucketRulePropertyFromCloudFormation(properties: any): cfn_parse.Fro
   }
   const ret = new cfn_parse.FromCloudFormationPropertyObject<CfnBucket.RuleProperty>();
   ret.addPropertyResult("abortIncompleteMultipartUpload", "AbortIncompleteMultipartUpload", (properties.AbortIncompleteMultipartUpload != null ? CfnBucketAbortIncompleteMultipartUploadPropertyFromCloudFormation(properties.AbortIncompleteMultipartUpload) : undefined));
-  ret.addPropertyResult("expirationDate", "ExpirationDate", (properties.ExpirationDate != null ? cfn_parse.FromCloudFormation.getString(properties.ExpirationDate) : undefined));
+  ret.addPropertyResult("expirationDate", "ExpirationDate", (properties.ExpirationDate != null ? cfn_parse.FromCloudFormation.getDate(properties.ExpirationDate) : undefined));
   ret.addPropertyResult("expirationInDays", "ExpirationInDays", (properties.ExpirationInDays != null ? cfn_parse.FromCloudFormation.getNumber(properties.ExpirationInDays) : undefined));
   ret.addPropertyResult("expiredObjectDeleteMarker", "ExpiredObjectDeleteMarker", (properties.ExpiredObjectDeleteMarker != null ? cfn_parse.FromCloudFormation.getBoolean(properties.ExpiredObjectDeleteMarker) : undefined));
   ret.addPropertyResult("id", "Id", (properties.Id != null ? cfn_parse.FromCloudFormation.getString(properties.Id) : undefined));

--- a/packages/@aws-cdk/service-spec-build/src/build-database.ts
+++ b/packages/@aws-cdk/service-spec-build/src/build-database.ts
@@ -34,7 +34,14 @@ export async function buildDatabase(options: BuildDatabaseOptions = {}) {
         db,
         resource,
         fails: warnings,
-        specResource: resourceSpec.ResourceTypes[resource.typeName],
+        resourceSpec: {
+          spec: resourceSpec.ResourceTypes[resource.typeName],
+          types: Object.fromEntries(
+            Object.entries(resourceSpec.PropertyTypes)
+              .filter(([typeName]) => typeName.startsWith(resource.typeName))
+              .map(([typeName, typeDef]) => [typeName.split('.').splice(1).join('.'), typeDef]),
+          ),
+        },
       });
       db.link('regionHasResource', region, res);
 

--- a/packages/@aws-cdk/service-spec/src/types/resource.ts
+++ b/packages/@aws-cdk/service-spec/src/types/resource.ts
@@ -163,7 +163,7 @@ export type PropertyType =
   | MapType<PropertyType>
   | TypeUnion<PropertyType>;
 
-export type PrimitiveType = StringType | NumberType | BooleanType | JsonType | NullType;
+export type PrimitiveType = StringType | NumberType | BooleanType | JsonType | DateTimeType | NullType;
 
 export function isPrimitiveType(x: PropertyType): x is PrimitiveType {
   return (x as any).type;
@@ -192,6 +192,10 @@ export interface JsonType {
 
 export interface NullType {
   readonly type: 'null';
+}
+
+export interface DateTimeType {
+  readonly type: 'date-time';
 }
 
 export interface DefinitionReference {

--- a/packages/@cdklabs/typewriter/src/renderer/typescript.ts
+++ b/packages/@cdklabs/typewriter/src/renderer/typescript.ts
@@ -49,7 +49,7 @@ import {
 } from '../statements';
 import { StructType } from '../struct';
 import { ThingSymbol } from '../symbol';
-import { Type } from '../type';
+import { PrimitiveType, Type } from '../type';
 import { TypeParameterSpec } from '../type-declaration';
 import { Initializer, MemberVisibility, Method } from '../type-member';
 
@@ -344,7 +344,12 @@ export class TypeScriptRenderer extends Renderer {
       return this.emit('void');
     }
     if (ref.primitive) {
-      return this.emit(ref.primitive);
+      switch (ref.primitive) {
+        case PrimitiveType.DateTime:
+          return this.emit('Date');
+        default:
+          return this.emit(ref.primitive);
+      }
     }
 
     if (ref.symbol) {

--- a/packages/@cdklabs/typewriter/src/type.ts
+++ b/packages/@cdklabs/typewriter/src/type.ts
@@ -8,9 +8,9 @@ import { MemberVisibility } from './type-member';
 
 export enum PrimitiveType {
   /**
-   * A JSON date (represented as it's ISO-8601 string form).
+   * A JSON date-time or date (represented as it's ISO-8601 string form).
    */
-  Date = 'date',
+  DateTime = 'date-time',
   /**
    * A plain string.
    */
@@ -56,6 +56,7 @@ export type TypeReferenceSpec =
 export class Type {
   public static readonly ANY = new Type({ primitive: PrimitiveType.Any });
   public static readonly VOID = new Type({ primitive: PrimitiveType.Void });
+  public static readonly DATE_TIME = new Type({ primitive: PrimitiveType.DateTime });
   public static readonly STRING = new Type({ primitive: PrimitiveType.String });
   public static readonly NUMBER = new Type({ primitive: PrimitiveType.Number });
   public static readonly BOOLEAN = new Type({ primitive: PrimitiveType.Boolean });


### PR DESCRIPTION
In the current spec, some properties are the primitive `Timestamp` type.
And in the L1s we convert these to native JS `Date`.
Unfortunately this information is not consistently available in the new schema.
We are now looking this type up from the old spec and amend it to the new schema.

Fixes #211 