### PR TITLE
fix(cfn2ts): aws-sam is not generated

### DIFF
--- a/packages/@aws-cdk/cfn2ts/src/index.ts
+++ b/packages/@aws-cdk/cfn2ts/src/index.ts
@@ -58,6 +58,9 @@ export default async function generate(
  * @example "AWS::DynamoDB" -> "aws-dynamodb"
  */
 function scopeToServiceName(scope: string): string {
+  if (scope === 'AWS::Serverless') {
+    return 'aws-sam';
+  }
   return scope.replace('::', '-').toLowerCase();
 }
 


### PR DESCRIPTION
Fixes `Cannot find module './sam.generated' or its corresponding type declarations.`