### PR TITLE
chore: build current aws-cdk-lib and compare spec with proposed new spec

### DIFF
--- a/.github/workflows/test-aws-cdk-integration.yml
+++ b/.github/workflows/test-aws-cdk-integration.yml
@@ -46,3 +46,38 @@ jobs:
       - name: Build aws/aws-cdk
         run: npx lerna run build --no-bail --scope aws-cdk-lib --include-dependencies
         working-directory: aws-cdk
+      - name: Prepare artifacts
+        run: |-
+          jq 'del(.devDependencies)' packages/aws-cdk-lib/package.json > ${{ runner.temp }}/package.json
+          cp packages/aws-cdk-lib/.jsii ${{ runner.temp }}/.jsii
+          cp packages/aws-cdk-lib/.jsii.gz ${{ runner.temp }}/.jsii.gz
+        working-directory: aws-cdk
+      - name: Upload spec
+        uses: actions/upload-artifact@v3
+        with:
+          name: aws-cdk-lib-candidate
+          if-no-files-found: error
+          path: |-
+            ${{ runner.temp }}/package.json
+            ${{ runner.temp }}/.jsii
+            ${{ runner.temp }}/.jsii.gz
+  jsii-diff:
+    needs: test-with-new-codegen
+    runs-on: awscdk-service-spec_ubuntu-latest_32-core
+    permissions: {}
+    env:
+      CI: "1"
+      NODE_OPTIONS: --max-old-space-size=8196
+    steps:
+      - name: Download aws-cdk-lib-candidate
+        uses: actions/download-artifact@v3
+        with:
+          name: aws-cdk-lib-candidate
+          path: aws-cdk-lib-candidate
+      - name: Prepare dependency closure
+        run: npm install
+        working-directory: aws-cdk-lib-candidate
+      - name: Install jsii-diff
+        run: npm install jsii-diff
+      - name: Compare current and candidate spec
+        run: npx jsii-diff --verbose npm:aws-cdk-lib@latest aws-cdk-lib-candidate

--- a/projenrc/aws-cdk-integration-test.ts
+++ b/projenrc/aws-cdk-integration-test.ts
@@ -21,15 +21,16 @@ export class AwsCdkIntegrationTest extends pj.Component {
       },
     });
 
-    const projectPath = path.join(root.name, path.relative(root.outdir, project.outdir));
+    const runsOn = ['awscdk-service-spec_ubuntu-latest_32-core'];
     const awsCdkRepo = 'aws/aws-cdk';
     const awsCdkPath = 'aws-cdk';
+    const candidateSpec = 'aws-cdk-lib-candidate';
+    const candidateSpecJobName = 'test-with-new-codegen';
 
-    workflow.addJob('test-with-new-codegen', {
-      runsOn: ['awscdk-service-spec_ubuntu-latest_32-core'],
+    workflow.addJob(candidateSpecJobName, {
+      runsOn,
       env: {
-        CI: '1',
-        NODE_OPTIONS: '--max-old-space-size=8196',
+        ...awsCdkLibEnv(),
       },
       permissions: {
         contents: pj.github.workflows.JobPermission.READ,
@@ -45,7 +46,6 @@ export class AwsCdkIntegrationTest extends pj.Component {
             lfs: true,
           },
         },
-
         {
           name: `Build ${root.name}`,
           workingDirectory: root.name,
@@ -55,35 +55,127 @@ export class AwsCdkIntegrationTest extends pj.Component {
             'yarn workspace @aws-cdk/service-spec-build run build:db',
           ].join('\n'),
         },
+        ...checkoutRepository(awsCdkRepo, awsCdkPath),
+        ...linkPackage(project, awsCdkPath),
+        ...buildAwsCdkLib(awsCdkRepo, awsCdkPath),
+        ...uploadSpec(candidateSpec, awsCdkPath),
+      ],
+    });
+
+    /**
+     * @TODO Separate job for now because this it is failing
+     * Once it passes, this should be merged with the main job above
+     */
+    workflow.addJob('jsii-diff', {
+      needs: [candidateSpecJobName],
+      runsOn,
+      env: {
+        ...awsCdkLibEnv(),
+      },
+      permissions: {},
+      steps: [
+        ...specFromArtifact(candidateSpec),
         {
-          name: `Checkout ${awsCdkRepo}`,
-          uses: 'actions/checkout@v3',
-          with: {
-            path: awsCdkPath,
-            repository: awsCdkRepo,
-          },
+          name: `Install jsii-diff`,
+          run: 'npm install jsii-diff',
         },
         {
-          name: `Register drop-in ${project.name} replacement`,
-          workingDirectory: projectPath,
-          run: 'yarn link',
-        },
-        {
-          name: `Link drop-in ${project.name} replacement`,
-          workingDirectory: awsCdkPath,
-          run: `yarn link "${project.name}"`,
-        },
-        {
-          name: `Setup ${awsCdkRepo}`,
-          workingDirectory: awsCdkPath,
-          run: 'yarn install',
-        },
-        {
-          name: `Build ${awsCdkRepo}`,
-          workingDirectory: awsCdkPath,
-          run: 'npx lerna run build --no-bail --scope aws-cdk-lib --include-dependencies',
+          name: `Compare current and candidate spec`,
+          run: `npx jsii-diff --verbose npm:aws-cdk-lib@latest ${candidateSpec}`,
         },
       ],
     });
   }
+}
+
+function awsCdkLibEnv(): Record<string, string> {
+  return {
+    CI: '1',
+    NODE_OPTIONS: '--max-old-space-size=8196',
+  };
+}
+
+function checkoutRepository(repository: string, path: string): pj.github.workflows.Step[] {
+  return [
+    {
+      name: `Checkout ${repository}`,
+      uses: 'actions/checkout@v3',
+      with: {
+        path,
+        repository,
+      },
+    },
+  ];
+}
+
+function linkPackage(project: pj.Project, targetPath: string): pj.github.workflows.Step[] {
+  const sourcePath = path.join(project.root.name, path.relative(project.root.outdir, project.outdir));
+  return [
+    {
+      name: `Register drop-in ${project.name} replacement`,
+      workingDirectory: sourcePath,
+      run: 'yarn link',
+    },
+    {
+      name: `Link drop-in ${project.name} replacement`,
+      workingDirectory: targetPath,
+      run: `yarn link "${project.name}"`,
+    },
+  ];
+}
+
+function buildAwsCdkLib(repository: string, path: string): pj.github.workflows.Step[] {
+  return [
+    {
+      name: `Setup ${repository}`,
+      workingDirectory: path,
+      run: 'yarn install',
+    },
+    {
+      name: `Build ${repository}`,
+      workingDirectory: path,
+      run: 'npx lerna run build --no-bail --scope aws-cdk-lib --include-dependencies',
+    },
+  ];
+}
+
+function uploadSpec(artifactName: string, workingDir: string): pj.github.workflows.Step[] {
+  return [
+    {
+      name: `Prepare artifacts`,
+      workingDirectory: workingDir,
+      run: [
+        `jq 'del(.devDependencies)' packages/aws-cdk-lib/package.json > \${{ runner.temp }}/package.json`,
+        `cp packages/aws-cdk-lib/.jsii \${{ runner.temp }}/.jsii`,
+        `cp packages/aws-cdk-lib/.jsii.gz \${{ runner.temp }}/.jsii.gz`,
+      ].join('\n'),
+    },
+    {
+      name: `Upload spec`,
+      uses: 'actions/upload-artifact@v3',
+      with: {
+        name: artifactName,
+        'if-no-files-found': 'error',
+        path: ['${{ runner.temp }}/package.json', '${{ runner.temp }}/.jsii', '${{ runner.temp }}/.jsii.gz'].join('\n'),
+      },
+    },
+  ];
+}
+
+function specFromArtifact(name: string): pj.github.workflows.Step[] {
+  return [
+    {
+      name: `Download ${name}`,
+      uses: 'actions/download-artifact@v3',
+      with: {
+        name: name,
+        path: name,
+      },
+    },
+    {
+      name: `Prepare dependency closure`,
+      workingDirectory: name,
+      run: 'npm install',
+    },
+  ];
 }


### PR DESCRIPTION
Fetch the latest released version of `aws-cdk-lib` and compare its jsii assembly with the proposed new spec.
Report and fail for any incompatible changes.

Note: This does not fail on external API changes yet. Needs a new jsii release for that and an update to the `jsii-diff` call.
Also does the diff in a separate job as we expect it to fail just now but want to enforce the compile step.