### PR TITLE
feat: split problem report by service

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -99,6 +99,7 @@ const buildDb = serviceSpecBuild.tasks.addTask('build:db', {
 serviceSpecBuild.postCompileTask.spawn(buildDb);
 serviceSpecBuild.gitignore.addPatterns('db.json');
 serviceSpecBuild.gitignore.addPatterns('db-build-report.txt');
+serviceSpecBuild.gitignore.addPatterns('build-report');
 
 const cfnResources = new TypeScriptWorkspace({
   parent: repo,

--- a/packages/@aws-cdk/service-spec-build/.gitignore
+++ b/packages/@aws-cdk/service-spec-build/.gitignore
@@ -46,3 +46,4 @@ junit.xml
 !/.eslintrc.js
 db.json
 db-build-report.txt
+build-report

--- a/packages/@aws-cdk/service-spec-build/src/import-canned-metrics.ts
+++ b/packages/@aws-cdk/service-spec-build/src/import-canned-metrics.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'crypto';
 import { SpecDatabase } from '@aws-cdk/service-spec';
-import { CloudWatchConsoleServiceDirectory } from '@aws-cdk/service-spec-sources';
-import { Entity, failure, Failures, Plain } from '@cdklabs/tskb';
+import { CloudWatchConsoleServiceDirectory, ProblemReport, ReportAudience } from '@aws-cdk/service-spec-sources';
+import { Entity, failure, Plain } from '@cdklabs/tskb';
 
 /**
  * Returns a deduplicatable entity
@@ -32,7 +32,7 @@ function dedup<T extends Plain<Entity>, K extends keyof T>(
 export function importCannedMetrics(
   db: SpecDatabase,
   serviceDirectoryEntries: CloudWatchConsoleServiceDirectory,
-  fails: Failures,
+  report: ProblemReport,
 ) {
   const skippedResources = new Set<string>();
 
@@ -75,6 +75,10 @@ export function importCannedMetrics(
   }
 
   for (const r of Array.from(skippedResources).sort()) {
-    fails.push(failure.in('CloudWatchConsoleServiceDirectory').in(r)('skipping resource type not in db'));
+    report.reportFailure(
+      ReportAudience.cdkTeam(),
+      'interpreting',
+      failure.in('CloudWatchConsoleServiceDirectory').in(r)('skipping resource type not in db'),
+    );
   }
 }

--- a/packages/@aws-cdk/service-spec-build/src/import-cloudformation-docs.ts
+++ b/packages/@aws-cdk/service-spec-build/src/import-cloudformation-docs.ts
@@ -1,14 +1,7 @@
 import { SpecDatabase } from '@aws-cdk/service-spec';
 import { cfndocs, CloudFormationDocumentation } from '@aws-cdk/service-spec-sources';
-import { Failures } from '@cdklabs/tskb';
 
-export function importCloudFormationDocumentation(
-  db: SpecDatabase,
-  docs: CloudFormationDocumentation,
-  fails: Failures,
-) {
-  Array.isArray(fails);
-
+export function importCloudFormationDocumentation(db: SpecDatabase, docs: CloudFormationDocumentation) {
   for (const [typeName, typeDocs] of Object.entries(docs.Types)) {
     const parts = typeName.split('.');
     if (parts.length === 2) {

--- a/packages/@aws-cdk/service-spec-build/src/import-sam.ts
+++ b/packages/@aws-cdk/service-spec-build/src/import-sam.ts
@@ -1,12 +1,17 @@
 import { Region, Service, SpecDatabase } from '@aws-cdk/service-spec';
-import { CloudFormationRegistryResource, jsonschema, SamTemplateSchema } from '@aws-cdk/service-spec-sources';
-import { chain, failure, Failures, liftUndefined, unpackOr } from '@cdklabs/tskb';
+import {
+  CloudFormationRegistryResource,
+  jsonschema,
+  ProblemReport,
+  SamTemplateSchema,
+} from '@aws-cdk/service-spec-sources';
+import { chain, failure, liftUndefined, unpackOr } from '@cdklabs/tskb';
 import { importCloudFormationRegistryResource } from './import-cloudformation-registry';
 
 export interface SamResourcesOptions {
   readonly db: SpecDatabase;
   readonly samSchema: SamTemplateSchema;
-  readonly fails: Failures;
+  readonly report: ProblemReport;
 }
 
 /**
@@ -38,7 +43,7 @@ export class SamResources {
 
       const resource = importCloudFormationRegistryResource({
         db: this.db,
-        fails: this.options.fails,
+        report: this.options.report,
         resource: resourceSpec,
       });
 

--- a/packages/@aws-cdk/service-spec-build/src/import-stateful-resources.ts
+++ b/packages/@aws-cdk/service-spec-build/src/import-stateful-resources.ts
@@ -1,15 +1,10 @@
 import { SpecDatabase } from '@aws-cdk/service-spec';
 import { StatefulResources } from '@aws-cdk/service-spec-sources';
-import { Failures } from '@cdklabs/tskb';
 
-export function importStatefulResources(db: SpecDatabase, stateful: StatefulResources, fails: Failures) {
-  Array.isArray(fails);
-
-  for (const [typeName, attrs] of Object.entries(stateful.ResourceTypes)) {
+export function importStatefulResources(db: SpecDatabase, stateful: StatefulResources) {
+  for (const [typeName, _] of Object.entries(stateful.ResourceTypes)) {
     for (const res of db.lookup('resource', 'cloudFormationType', 'equals', typeName)) {
       res.isStateful = true;
-
-      Array.isArray(attrs);
     }
   }
 }

--- a/packages/@aws-cdk/service-spec-build/test/canned-metrics.test.ts
+++ b/packages/@aws-cdk/service-spec-build/test/canned-metrics.test.ts
@@ -1,12 +1,13 @@
 import { emptyDatabase } from '@aws-cdk/service-spec';
-import { Failures } from '@cdklabs/tskb';
+import { ProblemReport } from '@aws-cdk/service-spec-sources';
 import { importCannedMetrics } from '../src/import-canned-metrics';
 
 let db: ReturnType<typeof emptyDatabase>;
-const warnings: Failures = [];
+let report: ProblemReport;
 
 beforeEach(() => {
   db = emptyDatabase();
+  report = new ProblemReport();
 
   // Put a service & a resource in the database
   const s = db.allocate('service', {
@@ -60,7 +61,7 @@ test('adds corresponding metrics to the database', () => {
         ],
       },
     ],
-    warnings,
+    report,
   );
 
   // THEN
@@ -118,7 +119,7 @@ test('does not add metrics for unknown resources', () => {
         ],
       },
     ],
-    warnings,
+    report,
   );
 
   // THEN

--- a/packages/@aws-cdk/service-spec-build/test/loading-docs.test.ts
+++ b/packages/@aws-cdk/service-spec-build/test/loading-docs.test.ts
@@ -1,13 +1,10 @@
 import { emptyDatabase, Resource } from '@aws-cdk/service-spec';
-import { Failures } from '@cdklabs/tskb';
 import { importCloudFormationDocumentation } from '../src/import-cloudformation-docs';
 
 let db: ReturnType<typeof emptyDatabase>;
-let fails: Failures;
 let resource: Resource;
 beforeEach(() => {
   db = emptyDatabase();
-  fails = [];
 
   // Put a resource in the database
   resource = db.allocate('resource', {
@@ -24,25 +21,21 @@ beforeEach(() => {
 
 test('add documentation to resources in database', () => {
   // WHEN
-  importCloudFormationDocumentation(
-    db,
-    {
-      Types: {
-        'AWS::Some::Type': {
-          description: 'This is a fancy type',
-          attributes: {
-            MyAttr: 'Cool attr',
-            Other: 'Not a cool attr',
-          },
-          properties: {
-            MyProp: 'Cool prop',
-            OtherProp: 'Not a cool prop',
-          },
+  importCloudFormationDocumentation(db, {
+    Types: {
+      'AWS::Some::Type': {
+        description: 'This is a fancy type',
+        attributes: {
+          MyAttr: 'Cool attr',
+          Other: 'Not a cool attr',
+        },
+        properties: {
+          MyProp: 'Cool prop',
+          OtherProp: 'Not a cool prop',
         },
       },
     },
-    fails,
-  );
+  });
 
   // THEN
   const res = db.lookup('resource', 'cloudFormationType', 'equals', 'AWS::Some::Type')[0];
@@ -62,21 +55,17 @@ test('add documentation to property types in database', () => {
   db.link('usesType', resource, typeDef);
 
   // WHEN
-  importCloudFormationDocumentation(
-    db,
-    {
-      Types: {
-        'AWS::Some::Type.MyType': {
-          description: 'This is a fancy type',
-          properties: {
-            SomeProp: 'Cool prop',
-            OtherProp: 'Not a cool prop',
-          },
+  importCloudFormationDocumentation(db, {
+    Types: {
+      'AWS::Some::Type.MyType': {
+        description: 'This is a fancy type',
+        properties: {
+          SomeProp: 'Cool prop',
+          OtherProp: 'Not a cool prop',
         },
       },
     },
-    fails,
-  );
+  });
 
   // THEN
   const typ = db.all('typeDefinition')[0];

--- a/packages/@aws-cdk/service-spec-build/test/property-conversion.test.ts
+++ b/packages/@aws-cdk/service-spec-build/test/property-conversion.test.ts
@@ -1,18 +1,18 @@
 import { DefinitionReference, emptyDatabase } from '@aws-cdk/service-spec';
-import { Failures } from '@cdklabs/tskb';
+import { ProblemReport } from '@aws-cdk/service-spec-sources';
 import { importCloudFormationRegistryResource } from '../src/import-cloudformation-registry';
 
 let db: ReturnType<typeof emptyDatabase>;
-let fails: Failures;
+let report: ProblemReport;
 beforeEach(() => {
   db = emptyDatabase();
-  fails = [];
+  report = new ProblemReport();
 });
 
 test('exclude readOnlyProperties from properties', () => {
   importCloudFormationRegistryResource({
     db,
-    fails,
+    report,
     resource: {
       description: 'Test resource',
       typeName: 'AWS::Some::Type',
@@ -33,7 +33,7 @@ test('exclude readOnlyProperties from properties', () => {
 test("don't exclude readOnlyProperties from properties that are also createOnlyProperties", () => {
   importCloudFormationRegistryResource({
     db,
-    fails,
+    report,
     resource: {
       description: 'Test resource',
       typeName: 'AWS::Some::Type',
@@ -56,7 +56,7 @@ test("don't exclude readOnlyProperties from properties that are also createOnlyP
 test('include readOnlyProperties in attributes', () => {
   importCloudFormationRegistryResource({
     db,
-    fails,
+    report,
     resource: {
       description: 'Test resource',
       typeName: 'AWS::Some::Type',
@@ -77,7 +77,7 @@ test('include readOnlyProperties in attributes', () => {
 test('compound readOnlyProperties are included in attributes', () => {
   importCloudFormationRegistryResource({
     db,
-    fails,
+    report,
     resource: {
       description: 'Test resource',
       typeName: 'AWS::Some::Type',
@@ -111,7 +111,7 @@ test('compound readOnlyProperties are included in attributes', () => {
 test('include legacy attributes in attributes', () => {
   importCloudFormationRegistryResource({
     db,
-    fails,
+    report,
     resource: {
       description: 'Test resource',
       typeName: 'AWS::Some::Type',
@@ -139,7 +139,7 @@ test('include legacy attributes in attributes', () => {
 test('reference types are correctly named', () => {
   importCloudFormationRegistryResource({
     db,
-    fails,
+    report,
     resource: {
       description: 'Test resource',
       typeName: 'AWS::Some::Type',
@@ -181,7 +181,7 @@ test('reference types are correctly named', () => {
 test('legacy timestamps are getting the timestamp format', () => {
   importCloudFormationRegistryResource({
     db,
-    fails,
+    report,
     resource: {
       description: 'Test resource',
       typeName: 'AWS::Some::Type',

--- a/packages/@aws-cdk/service-spec-build/test/sam-resources.test.ts
+++ b/packages/@aws-cdk/service-spec-build/test/sam-resources.test.ts
@@ -1,6 +1,5 @@
 import { emptyDatabase } from '@aws-cdk/service-spec';
-import { SamTemplateSchema, jsonschema } from '@aws-cdk/service-spec-sources';
-import { Failures } from '@cdklabs/tskb';
+import { ProblemReport, SamTemplateSchema, jsonschema } from '@aws-cdk/service-spec-sources';
 import { SamResources } from '../src/import-sam';
 
 const standardCfnProperties: jsonschema.ObjectProperties = {
@@ -91,10 +90,10 @@ test('import SAM types by recognizing the Type field that accepts a constant', (
   };
 
   const db = emptyDatabase();
-  const fails: Failures = [];
+  const report = new ProblemReport();
 
   // WHEN
-  new SamResources({ db, fails, samSchema }).import();
+  new SamResources({ db, report, samSchema }).import();
 
   // THEN
   const thing = db.lookup('resource', 'cloudFormationType', 'equals', 'AWS::Serverless::Thing').only();

--- a/packages/@aws-cdk/service-spec-build/test/stateful-resources.test.ts
+++ b/packages/@aws-cdk/service-spec-build/test/stateful-resources.test.ts
@@ -1,12 +1,9 @@
 import { emptyDatabase } from '@aws-cdk/service-spec';
-import { Failures } from '@cdklabs/tskb';
 import { importStatefulResources } from '../src/import-stateful-resources';
 
 let db: ReturnType<typeof emptyDatabase>;
-let fails: Failures;
 beforeEach(() => {
   db = emptyDatabase();
-  fails = [];
 
   // Put a resource in the database
   db.allocate('resource', {
@@ -23,15 +20,11 @@ beforeEach(() => {
 
 test('mark resource types as stateful', () => {
   // WHEN
-  importStatefulResources(
-    db,
-    {
-      ResourceTypes: {
-        'AWS::Some::Type': {},
-      },
+  importStatefulResources(db, {
+    ResourceTypes: {
+      'AWS::Some::Type': {},
     },
-    fails,
-  );
+  });
 
   // THEN
   const res = db.lookup('resource', 'cloudFormationType', 'equals', 'AWS::Some::Type')[0];

--- a/packages/@aws-cdk/service-spec-sources/src/index.ts
+++ b/packages/@aws-cdk/service-spec-sources/src/index.ts
@@ -3,3 +3,4 @@ export * from './schema-manipulation/unify-schemas';
 export * from './patching/format-patch-report';
 export * from './patching/patching';
 export * from './loading';
+export * from './report';

--- a/packages/@aws-cdk/service-spec-sources/src/loading/load-cloudformation-docs.ts
+++ b/packages/@aws-cdk/service-spec-sources/src/loading/load-cloudformation-docs.ts
@@ -1,18 +1,21 @@
 import * as path from 'path';
 import { assertSuccess } from '@cdklabs/tskb';
-import { Loader, LoadResult } from './loader';
+import { Loader } from './loader';
+import { ProblemReport, ReportAudience } from '../report';
 import { CloudFormationDocumentation } from '../types';
 
 export async function loadDefaultCloudFormationDocs(
+  report: ProblemReport,
   mustValidate = true,
-): Promise<LoadResult<CloudFormationDocumentation>> {
+): Promise<CloudFormationDocumentation> {
   const loader = await Loader.fromSchemaFile<CloudFormationDocumentation>('CloudFormationDocumentation.schema.json', {
     mustValidate,
+    report: report.forAudience(ReportAudience.cdkTeam()),
   });
 
   const result = await loader.loadFile(
     path.join(__dirname, '../../../../../sources/CloudFormationDocumentation/CloudFormationDocumentation.json'),
   );
   assertSuccess(result);
-  return result;
+  return result.value;
 }

--- a/packages/@aws-cdk/service-spec-sources/src/report/index.ts
+++ b/packages/@aws-cdk/service-spec-sources/src/report/index.ts
@@ -1,0 +1,1 @@
+export * from './problem-report';

--- a/packages/@aws-cdk/service-spec-sources/src/report/problem-report.ts
+++ b/packages/@aws-cdk/service-spec-sources/src/report/problem-report.ts
@@ -1,0 +1,106 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { Failure, errorMessage, failure } from '@cdklabs/tskb';
+import { PatchReport, formatPatchReport } from '../patching';
+
+export type ReportType = 'interpreting' | 'loading' | 'patch';
+
+interface Report {
+  readonly type: ReportType;
+  readonly failure: Failure;
+}
+
+/**
+ * A class to build a problem report for issues encountered during the spec import
+ */
+export class ProblemReport {
+  public readonly counts: Record<ReportType, number> = {
+    interpreting: 0,
+    loading: 0,
+    patch: 0,
+  };
+  public readonly patchesApplied = new Array<PatchReport>();
+  private readonly reportMap = new Map<string, Report[]>();
+
+  /**
+   * Report a failure into the problem report
+   */
+  public reportFailure(aud: ReportAudience, type: ReportType, ...failures: Failure[]) {
+    if (failures.length === 0) {
+      return;
+    }
+
+    let lst = this.reportMap.get(aud.id);
+    if (!lst) {
+      lst = [];
+      this.reportMap.set(aud.id, lst);
+    }
+    lst.push(...failures.map((f) => ({ failure: f, type })));
+    this.counts[type] += failures.length;
+  }
+
+  public reportPatch(aud: ReportAudience, ...patches: PatchReport[]) {
+    this.reportFailure(aud, 'patch', ...patches.map((p) => failure(formatPatchReport(p))));
+    this.patchesApplied.push(...patches);
+  }
+
+  public forAudience(aud: ReportAudience) {
+    return new BoundProblemReport(this, aud);
+  }
+
+  public async write(directory: string) {
+    await fs.rm(directory, { force: true, recursive: true });
+    await fs.mkdir(directory, { recursive: true });
+
+    for (const [id, reportList] of this.reportMap.entries()) {
+      await this.writeReportFile(path.join(directory, `${id}.txt`), id, reportList);
+    }
+  }
+
+  private async writeReportFile(fileName: string, service: string, reportList: Report[]) {
+    const lines = [];
+    lines.push(
+      `CDK found the following issues while trying to read the CloudFormation resource definition for ${service}:`,
+    );
+
+    const reportTypeOrder: ReportType[] = ['interpreting', 'loading', 'patch'];
+    for (const type of reportTypeOrder) {
+      const thisType = reportList.filter((r) => r.type === type);
+      if (thisType.length === 0) {
+        continue;
+      }
+
+      lines.push('');
+      lines.push(`    *** ${type} ***`);
+      lines.push('');
+      for (const rep of thisType) {
+        lines.push(errorMessage(rep.failure));
+      }
+    }
+
+    await fs.writeFile(fileName, lines.join('\n'), { encoding: 'utf-8' });
+  }
+}
+
+export class BoundProblemReport {
+  constructor(private readonly report: ProblemReport, private readonly aud: ReportAudience) {}
+  /**
+   * Report a failure into the problem report
+   */
+  public reportFailure(type: ReportType, ...failures: Failure[]) {
+    this.report.reportFailure(this.aud, type, ...failures);
+  }
+}
+
+export class ReportAudience {
+  public static fromCloudFormationResource(res: string) {
+    const parts = res.split('::');
+    return new ReportAudience(`AWS_${parts[1]}`);
+  }
+
+  public static cdkTeam() {
+    return new ReportAudience('CDK_Team');
+  }
+
+  constructor(public readonly id: string) {}
+}

--- a/packages/@aws-cdk/service-spec-sources/src/report/sorting.ts
+++ b/packages/@aws-cdk/service-spec-sources/src/report/sorting.ts
@@ -1,0 +1,27 @@
+/**
+ * Make a sorting comparator that will sort by a given sort key
+ */
+export function sortKeyComparator<A>(keyFn: (x: A) => Array<string | number>) {
+  return (a: A, b: A): number => {
+    const ak = keyFn(a);
+    const bk = keyFn(b);
+
+    for (let i = 0; i < ak.length && i < bk.length; i++) {
+      const av = ak[i];
+      const bv = bk[i];
+
+      let diff = 0;
+      if (typeof av === 'number' && typeof bv === 'number') {
+        diff = av - bv;
+      } else if (typeof av === 'string' && typeof bv === 'string') {
+        diff = av.localeCompare(bv);
+      }
+
+      if (diff !== 0) {
+        return diff;
+      }
+    }
+
+    return bk.length - ak.length;
+  };
+}

--- a/packages/@aws-cdk/service-spec-sources/src/tools/validate-registry-resources.ts
+++ b/packages/@aws-cdk/service-spec-sources/src/tools/validate-registry-resources.ts
@@ -2,15 +2,16 @@
 //
 // Not a lot of thought given to where this needs to live yet.
 import * as path from 'path';
-import { errorMessage } from '@cdklabs/tskb';
 import { loadDefaultCloudFormationRegistryResources } from '../loading';
 import { formatPatchReport, PatchReport } from '../patching';
+import { ProblemReport } from '../report';
 
 async function main() {
-  const allResources = await loadDefaultCloudFormationRegistryResources(false);
+  const report = new ProblemReport();
+  await loadDefaultCloudFormationRegistryResources(report, false);
 
-  if (allResources.patchesApplied.length > 0) {
-    const patches = uniqueReports(allResources.patchesApplied);
+  if (report.patchesApplied.length > 0) {
+    const patches = uniqueReports(report.patchesApplied);
     console.log(`${patches.length} patches applied to sources`);
     console.log('===========================================');
     console.log();
@@ -20,15 +21,11 @@ async function main() {
     }
   }
 
-  if (allResources.warnings.length > 0) {
-    console.log(`${allResources.warnings.length} schema files do not validate (after patching)`);
+  if (report.counts.interpreting + report.counts.loading > 0) {
+    console.log(`${report.counts.interpreting + report.counts.loading} problems remaining after patching`);
     console.log('===========================================');
     console.log();
     process.exitCode = 1;
-
-    for (const fail of allResources.warnings) {
-      console.log(errorMessage(fail));
-    }
   }
 }
 


### PR DESCRIPTION
Instead of dumping all problems into a single file, split problems out into different files for each service. This will make it easier to report problems upstream in the future.

Fixes #