### PR TITLE
fix(service-spec-sources): edge case where array types don't get the name of the definition

### DIFF
--- a/packages/@aws-cdk/service-spec-sources/src/types/registry-schema/JsonSchema.ts
+++ b/packages/@aws-cdk/service-spec-sources/src/types/registry-schema/JsonSchema.ts
@@ -225,6 +225,10 @@ export namespace jsonschema {
     readonly arrayType?: 'AttributeList' | 'Standard';
   }
 
+  export function isArray(x: ConcreteSchema): x is SchemaArray {
+    return isConcreteSingleton(x) && !isAnyType(x) && x.type === 'array';
+  }
+
   export interface Boolean extends Annotatable {
     readonly type: 'boolean';
     readonly default?: boolean;
@@ -267,6 +271,8 @@ export namespace jsonschema {
               allOf: ref.allOf.map((x) => resolve(x).schema),
             },
           };
+        } else if (isArray(ref) && ref.items && isReference(ref.items)) {
+          return { schema: ref, referenceName: ref.items.$ref.substring(2).split('/').at(-1) };
         } else {
           return { schema: ref };
         }


### PR DESCRIPTION
There is an edge with nested array types, where we loose the definition name for the type and incorrectly fallback to the prop name.

Fixes 9 issues with jsii-diff.