### PR TITLE
chore(aws-service-spec): don't require confirmation for gzip

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -119,11 +119,12 @@ const awsServiceSpec = new TypeScriptWorkspace({
 // Needs to be added to 'compile' task, because the integ tests will 'compile' everything (but not run the tests and linter).
 awsServiceSpec.compileTask.prependSpawn(
   awsServiceSpec.tasks.addTask('generate', {
-    exec: `node -e 'require("${serviceSpecBuild.name}/lib/cli/build")' && gzip db.json`,
+    exec: `node -e 'require("${serviceSpecBuild.name}/lib/cli/build")' && gzip db.json -f`,
     receiveArgs: true,
   }),
 );
 
+awsServiceSpec.gitignore.addPatterns('db.json');
 awsServiceSpec.gitignore.addPatterns('db.json.gz');
 awsServiceSpec.gitignore.addPatterns('build-report');
 awsServiceSpec.npmignore?.addPatterns('build-report');

--- a/packages/@aws-cdk/aws-service-spec/.gitignore
+++ b/packages/@aws-cdk/aws-service-spec/.gitignore
@@ -44,5 +44,6 @@ junit.xml
 /dist/
 !/.eslintrc.json
 !/.eslintrc.js
+db.json
 db.json.gz
 build-report

--- a/packages/@aws-cdk/aws-service-spec/.projen/tasks.json
+++ b/packages/@aws-cdk/aws-service-spec/.projen/tasks.json
@@ -79,7 +79,7 @@
       "name": "generate",
       "steps": [
         {
-          "exec": "node -e 'require(\"@aws-cdk/service-spec-build/lib/cli/build\")' && gzip db.json",
+          "exec": "node -e 'require(\"@aws-cdk/service-spec-build/lib/cli/build\")' && gzip db.json -f",
           "receiveArgs": true
         }
       ]


### PR DESCRIPTION
Previously the build paused at the `gzip` command waiting for confirmation to overwrite the existing file.
Also gitignore the unzipped `db.json` file so it doesn't accidentally end up in the repo.