### PR TITLE
chore: set npm publish config for released packages

### DIFF
--- a/packages/@aws-cdk/aws-service-spec/package.json
+++ b/packages/@aws-cdk/aws-service-spec/package.json
@@ -47,6 +47,9 @@
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "version": "0.0.0",
   "jest": {
     "testMatch": [

--- a/packages/@aws-cdk/service-spec-types/package.json
+++ b/packages/@aws-cdk/service-spec-types/package.json
@@ -43,6 +43,9 @@
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "version": "0.0.0",
   "jest": {
     "testMatch": [

--- a/packages/@cdklabs/tskb/package.json
+++ b/packages/@cdklabs/tskb/package.json
@@ -40,6 +40,9 @@
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "version": "0.0.0",
   "jest": {
     "testMatch": [

--- a/packages/@cdklabs/typewriter/package.json
+++ b/packages/@cdklabs/typewriter/package.json
@@ -40,6 +40,9 @@
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "version": "0.0.0",
   "jest": {
     "testMatch": [


### PR DESCRIPTION
Fixes attempt to publish as private package: `402 Payment Required: You must sign up for private packages`
See https://github.com/cdklabs/awscdk-service-spec/actions/runs/5411843113/jobs/9835226797#step:5:36