### PR TITLE
chore: release weekly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@
 
 name: release
 on:
+  schedule:
+    - cron: 11 8 * * 5
   workflow_dispatch: {}
 jobs:
   release:

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -36,10 +36,9 @@ const repo = new YarnMonorepo({
   release: true,
   releaseOptions: {
     publishToNpm: true,
-    releaseTrigger: {
-      isContinuous: false,
-      isManual: false,
-    },
+    releaseTrigger: pj.release.ReleaseTrigger.scheduled({
+      schedule: '11 8 * * 5',
+    }),
   },
 });
 


### PR DESCRIPTION
Release weekly on a Friday so we can import the latest spec into `aws/aws-cdk` over the weekend.