### PR TITLE
fix(aws-service-spec): include .jsiidiffignore in package

### DIFF
--- a/packages/@aws-cdk/aws-service-spec/.npmignore
+++ b/packages/@aws-cdk/aws-service-spec/.npmignore
@@ -20,4 +20,3 @@ tsconfig.tsbuildinfo
 /dist/changelog.md
 /dist/version.txt
 build-report
-.jsiidiffignore

--- a/projenrc/aws-cdk-integration-test.ts
+++ b/projenrc/aws-cdk-integration-test.ts
@@ -33,7 +33,6 @@ export class AwsCdkIntegrationTest extends pj.Component {
       path.relative(options.serviceSpec.root.outdir, options.serviceSpec.outdir),
       jsiiDiffIgnore,
     );
-    options.serviceSpec.addPackageIgnore(jsiiDiffIgnore);
 
     workflow.addJob(candidateSpecJobName, {
       runsOn,


### PR DESCRIPTION
This way we can access the information from in downstream packages and don't have to keep the information twice.