### PR TITLE
fix(service-spec-sources): remove CCAPI only properties

### DIFF
--- a/packages/@aws-cdk/service-spec-sources/src/patches/service-patches/cloudformation.ts
+++ b/packages/@aws-cdk/service-spec-sources/src/patches/service-patches/cloudformation.ts
@@ -1,0 +1,25 @@
+import { forResource, registerServicePatches, removeResourceProperty } from './core';
+import { Reason } from '../../patching';
+
+const reason = Reason.sourceIssue('Property is only supported by the CCAPI');
+
+registerServicePatches(
+  forResource('AWS::CloudFormation::Stack', (lens) => {
+    const ccapiOnlyProps = [
+      'Capabilities',
+      'Description',
+      'DisableRollback',
+      'EnableTerminationProtection',
+      'RoleARN',
+      'StackName',
+      'StackPolicyBody',
+      'StackPolicyURL',
+      'StackStatusReason',
+      'TemplateBody',
+    ];
+
+    for (const prop of ccapiOnlyProps) {
+      removeResourceProperty(prop, reason)(lens);
+    }
+  }),
+);

--- a/packages/@aws-cdk/service-spec-sources/src/patches/service-patches/index.ts
+++ b/packages/@aws-cdk/service-spec-sources/src/patches/service-patches/index.ts
@@ -14,6 +14,7 @@ export { SERVICE_PATCHERS as EXCEPTIONS_PATCHERS } from './core';
 // Services
 import './autoscaling';
 import './batch';
+import './cloudformation';
 import './codebuild';
 import './cognito';
 import './config';


### PR DESCRIPTION
The Service Team has informed us about the imminent release of a new schema version that contains properties that are only supported by the CCAPI, but not CloudFormation.
This changes patches these properties out when they are published.