### PR TITLE
chore: remove redundant step from integration test setup

### DIFF
--- a/.github/workflows/test-aws-cdk-integration.yml
+++ b/.github/workflows/test-aws-cdk-integration.yml
@@ -45,9 +45,6 @@ jobs:
       - name: Link drop-in @aws-cdk/service-spec-types replacement
         run: yarn link "@aws-cdk/service-spec-types"
         working-directory: aws-cdk
-      - name: Use spec2cdk
-        run: echo "export * from '@aws-cdk/spec2cdk/lib/cfn2ts';" > packages/aws-cdk-lib/scripts/codegen.ts
-        working-directory: aws-cdk
       - name: Setup aws/aws-cdk
         run: yarn install
         working-directory: aws-cdk

--- a/projenrc/aws-cdk-integration-test.ts
+++ b/projenrc/aws-cdk-integration-test.ts
@@ -61,7 +61,6 @@ export class AwsCdkIntegrationTest extends pj.Component {
         ...checkoutRepository(awsCdkRepo, awsCdkPath),
         ...linkPackage(options.serviceSpec, awsCdkPath),
         ...linkPackage(options.serviceSpecTypes, awsCdkPath),
-        ...useSpec2Cdk(awsCdkPath),
         ...buildAwsCdkLib(awsCdkRepo, awsCdkPath),
         ...runJsiiDiff(candidateSpec, diffIgnoreFile),
       ],
@@ -101,16 +100,6 @@ function linkPackage(project: pj.Project, targetPath: string): pj.github.workflo
       name: `Link drop-in ${project.name} replacement`,
       workingDirectory: targetPath,
       run: `yarn link "${project.name}"`,
-    },
-  ];
-}
-
-function useSpec2Cdk(path: string): pj.github.workflows.Step[] {
-  return [
-    {
-      name: `Use spec2cdk`,
-      workingDirectory: path,
-      run: `echo "export * from '@aws-cdk/spec2cdk/lib/cfn2ts';" > packages/aws-cdk-lib/scripts/codegen.ts`,
     },
   ];
 }


### PR DESCRIPTION
This step is not needed anymore since `aws/aws-cdk` is now officially using the new service-spec.
Previously we needed to overwrite the import statement to use the new code.