### PR TITLE
chore: disable breaking change checking on specs

### DIFF
--- a/.github/workflows/test-aws-cdk-integration.yml
+++ b/.github/workflows/test-aws-cdk-integration.yml
@@ -51,7 +51,3 @@ jobs:
       - name: Build aws/aws-cdk
         run: npx lerna run build --no-bail --scope aws-cdk-lib --include-dependencies
         working-directory: aws-cdk
-      - name: Install jsii-diff
-        run: npm install -g jsii-diff
-      - name: Compare current and candidate spec
-        run: npx jsii-diff --verbose --keys --ignore-file=awscdk-service-spec/packages/@aws-cdk/aws-service-spec/.jsiidiffignore --error-on=non-experimental npm:aws-cdk-lib@latest aws-cdk/packages/aws-cdk-lib

--- a/projenrc/aws-cdk-integration-test.ts
+++ b/projenrc/aws-cdk-integration-test.ts
@@ -62,9 +62,12 @@ export class AwsCdkIntegrationTest extends pj.Component {
         ...linkPackage(options.serviceSpec, awsCdkPath),
         ...linkPackage(options.serviceSpecTypes, awsCdkPath),
         ...buildAwsCdkLib(awsCdkRepo, awsCdkPath),
-        ...runJsiiDiff(candidateSpec, diffIgnoreFile),
+        // Temporarily disabled, as it regularly prevents legitimate spec imports with intentional breaking changes.
+        // Instead, we need to add more purposeful validations like type renames.
+        // ...runJsiiDiff(candidateSpec, diffIgnoreFile),
       ],
     });
+    void runJsiiDiff, candidateSpec, diffIgnoreFile;
   }
 }
 


### PR DESCRIPTION
We currently do not merge PRs that introduce breaking changes into the spec without human intervention.

Many of these breaking changes are on purpose though, to rectify human errors made in the spec in the past. The upshot is that spec updates often don't get merged.

Disable breaking change checks using `jsii-diff`. Egregious breakage will still be caught if it stops `aws-cdk-lib` from compiling.
