### PR TITLE
fix: empty type definitions are generated

### DIFF
--- a/packages/@aws-cdk/service-spec-build/test/property-conversion.test.ts
+++ b/packages/@aws-cdk/service-spec-build/test/property-conversion.test.ts
@@ -1,5 +1,5 @@
 import { ProblemReport } from '@aws-cdk/service-spec-sources';
-import { DefinitionReference, emptyDatabase } from '@aws-cdk/service-spec-types';
+import { DefinitionReference, PropertyType, emptyDatabase } from '@aws-cdk/service-spec-types';
 import { importCloudFormationRegistryResource } from '../src/import-cloudformation-registry';
 
 let db: ReturnType<typeof emptyDatabase>;
@@ -302,4 +302,38 @@ test('read required properties from allOf/anyOf', () => {
     .filter(([_, value]) => value.required)
     .map(([name, _]) => name);
   expect(requiredProps).toContain('InBoth');
+});
+
+test('only object types get type definitions', () => {
+  importCloudFormationRegistryResource({
+    db,
+    report,
+    resource: {
+      typeName: 'AWS::Test::Resource',
+      description: 'Test resource',
+      properties: {
+        Prop1: { $ref: '#/definitions/Type1' },
+        Prop2: { $ref: '#/definitions/Type2' },
+        Prop3: { $ref: '#/definitions/Type3' },
+      },
+      additionalProperties: false,
+      definitions: {
+        Type1: { type: 'array', items: { type: 'string' } },
+        Type2: { type: 'object' },
+        Type3: {
+          type: 'object',
+          properties: {
+            field: { type: 'string' },
+          },
+          additionalProperties: false,
+        },
+      },
+    },
+  });
+
+  const resource = db.lookup('resource', 'cloudFormationType', 'equals', 'AWS::Test::Resource').only();
+  const typeNames = db.follow('usesType', resource).map((e) => e.entity.name);
+  expect(typeNames).toEqual(['Type3']);
+  expect(resource.properties.Prop1.type).toEqual({ type: 'array', element: { type: 'string' } } satisfies PropertyType);
+  expect(resource.properties.Prop2.type).toEqual({ type: 'json' });
 });


### PR DESCRIPTION
If the CloudFormation Registry schema contains a type definition for an typed object type:

```
{
  definitions: {
    SomeType: {
      type: 'object',
    },
  }
}
```

We would generate an empty type definitino for `SomeType`, instead of treating it as an alias for `{ type: 'json' }`.

The aliasing is more appropriate and compatible with how we traditionally interpreted the legacy spec.

Fixes #