### PR TITLE
chore: remove debug line

### DIFF
--- a/packages/@aws-cdk/service-spec-importers/src/import-resource-spec.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/import-resource-spec.ts
@@ -26,8 +26,6 @@ abstract class ResourceSpecImporterBase<Spec extends CloudFormationResourceSpeci
     protected readonly specification: Spec,
     protected readonly resourceName: string,
   ) {
-    this.renderingUnusedTypes = true; // FIXME: DON'T COMMIT, just for testing
-
     const specBuilder = new SpecBuilder(db);
     this.resourceBuilder = specBuilder.resourceBuilder(resourceName, {
       description: specification.ResourceTypes[resourceName].Documentation,


### PR DESCRIPTION
The current behavior marks every type as legacy, which is not wrong, but it would be more useful to only mark the unused types as legacy.