### PR TITLE
fix: diff counts reordered union elements as a change

### DIFF
--- a/packages/@aws-cdk/service-spec-importers/src/db-diff.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/db-diff.ts
@@ -40,7 +40,7 @@ export class DbDiff {
     };
   }
 
-  private diffService(a: Service, b: Service): UpdatedService | undefined {
+  public diffService(a: Service, b: Service): UpdatedService | undefined {
     return collapseUndefined({
       capitalized: diffScalar(a, b, 'capitalized'),
       cloudFormationNamespace: diffScalar(a, b, 'cloudFormationNamespace'),
@@ -50,7 +50,7 @@ export class DbDiff {
     } satisfies AllFieldsGiven<UpdatedService>);
   }
 
-  private diffServiceResources(a: Service, b: Service): UpdatedService['resourceDiff'] {
+  public diffServiceResources(a: Service, b: Service): UpdatedService['resourceDiff'] {
     const aRes = this.db1.follow('hasResource', a).map((r) => r.entity);
     const bRes = this.db2.follow('hasResource', b).map((r) => r.entity);
 
@@ -64,7 +64,7 @@ export class DbDiff {
     );
   }
 
-  private diffResource(a: Resource, b: Resource): UpdatedResource | undefined {
+  public diffResource(a: Resource, b: Resource): UpdatedResource | undefined {
     return collapseUndefined({
       cloudFormationTransform: diffScalar(a, b, 'cloudFormationTransform'),
       documentation: diffScalar(a, b, 'documentation'),
@@ -80,7 +80,7 @@ export class DbDiff {
     } satisfies AllFieldsGiven<UpdatedResource>);
   }
 
-  private diffAttribute(a: Attribute, b: Attribute): UpdatedAttribute | undefined {
+  public diffAttribute(a: Attribute, b: Attribute): UpdatedAttribute | undefined {
     const eqType = this.eqType.bind(this);
 
     const anyDiffs = collapseUndefined({
@@ -95,7 +95,7 @@ export class DbDiff {
     return undefined;
   }
 
-  private diffProperty(a: Property, b: Property): UpdatedProperty | undefined {
+  public diffProperty(a: Property, b: Property): UpdatedProperty | undefined {
     const eqType = this.eqType.bind(this);
 
     const anyDiffs = collapseUndefined({
@@ -115,7 +115,7 @@ export class DbDiff {
     return undefined;
   }
 
-  private diffResourceTypeDefinitions(a: Resource, b: Resource): UpdatedResource['typeDefinitionDiff'] {
+  public diffResourceTypeDefinitions(a: Resource, b: Resource): UpdatedResource['typeDefinitionDiff'] {
     const aTypes = this.db1.follow('usesType', a).map((r) => r.entity);
     const bTypes = this.db2.follow('usesType', b).map((r) => r.entity);
 
@@ -129,7 +129,7 @@ export class DbDiff {
     );
   }
 
-  private diffTypeDefinition(a: TypeDefinition, b: TypeDefinition): UpdatedTypeDefinition | undefined {
+  public diffTypeDefinition(a: TypeDefinition, b: TypeDefinition): UpdatedTypeDefinition | undefined {
     return collapseUndefined({
       documentation: diffScalar(a, b, 'documentation'),
       name: diffScalar(a, b, 'name'),
@@ -145,8 +145,8 @@ export class DbDiff {
    * Solve it by doing a string-render and comparing those (for now).
    */
   private eqType(a: PropertyType, b: PropertyType): boolean {
-    const s1 = new RichPropertyType(a).stringify(this.db1, false);
-    const s2 = new RichPropertyType(b).stringify(this.db2, false);
+    const s1 = new RichPropertyType(a).normalize(this.db1).stringify(this.db1, false);
+    const s2 = new RichPropertyType(b).normalize(this.db2).stringify(this.db2, false);
     return s1 === s2;
   }
 }

--- a/packages/@aws-cdk/service-spec-importers/test/db-diff.test.ts
+++ b/packages/@aws-cdk/service-spec-importers/test/db-diff.test.ts
@@ -1,0 +1,31 @@
+import { DbDiff } from '../src/db-diff';
+import { ref } from '@cdklabs/tskb';
+import { emptyDatabase, SpecDatabase } from '@aws-cdk/service-spec-types';
+
+let db1: SpecDatabase;
+let db2: SpecDatabase;
+let diff: DbDiff;
+beforeEach(() => {
+  db1 = emptyDatabase();
+  db2 = emptyDatabase();
+  diff = new DbDiff(db1, db2);
+});
+
+test('property diff ignores union order', () => {
+  const pd = diff.diffProperty(
+    { type: { type: 'union', types: [{ type: 'string' }, { type: 'number' }] } },
+    { type: { type: 'union', types: [{ type: 'number' }, { type: 'string' }] } },
+  );
+  expect(pd).toBeUndefined();
+});
+
+test('property diff ignores union order, even when using type references', () => {
+  const t1 = db1.allocate('typeDefinition', { name: 'MyType', properties: {} });
+  const t2 = db2.allocate('typeDefinition', { name: 'MyType', properties: {} });
+
+  const pd = diff.diffProperty(
+    { type: { type: 'union', types: [{ type: 'string' }, { type: 'ref', reference: ref(t1) }] } },
+    { type: { type: 'union', types: [{ type: 'ref', reference: ref(t2) }, { type: 'string' }] } },
+  );
+  expect(pd).toBeUndefined();
+});

--- a/packages/@aws-cdk/service-spec-types/src/types/resource.ts
+++ b/packages/@aws-cdk/service-spec-types/src/types/resource.ts
@@ -493,6 +493,31 @@ export class RichPropertyType {
     }
   }
 
+  /**
+   * Return a version of this type, but with all type unions in a regularized order
+   */
+  public normalize(db: SpecDatabase): RichPropertyType {
+    switch (this.type.type) {
+      case 'array':
+      case 'map':
+        return new RichPropertyType({
+          type: this.type.type,
+          element: new RichPropertyType(this.type.element).normalize(db).type,
+        });
+      case 'union':
+        const types = this.type.types
+          .map((t) => new RichPropertyType(t).normalize(db))
+          .map((t) => [t, t.sortKey(db)] as const);
+        types.sort(sortKeyComparator(([_, sortKey]) => sortKey));
+        return new RichPropertyType({
+          type: 'union',
+          types: types.map(([t, _]) => t.type),
+        });
+      default:
+        return this;
+    }
+  }
+
   public stringify(db: SpecDatabase, withId = true): string {
     switch (this.type.type) {
       case 'integer':
@@ -516,7 +541,13 @@ export class RichPropertyType {
     }
   }
 
-  public sortKey(): string[] {
+  /**
+   * Return a sortable key based on this type
+   *
+   * If a database is given, type definitions will be sorted based on type name,
+   * otherwise on identifier
+   */
+  public sortKey(db?: SpecDatabase): string[] {
     switch (this.type.type) {
       case 'integer':
       case 'boolean':
@@ -526,16 +557,16 @@ export class RichPropertyType {
       case 'number':
       case 'string':
       case 'tag':
-        return [this.type.type];
+        return ['0', this.type.type];
       case 'array':
       case 'map':
-        return [this.type.type, ...new RichPropertyType(this.type.element).sortKey()];
+        return ['1', this.type.type, ...new RichPropertyType(this.type.element).sortKey(db)];
       case 'ref':
-        return [this.type.type, this.type.reference.$ref];
+        return ['2', this.type.type, db?.get('typeDefinition', this.type.reference)?.name ?? this.type.reference.$ref];
       case 'union':
-        const typeKeys = this.type.types.map((t) => new RichPropertyType(t).sortKey());
+        const typeKeys = this.type.types.map((t) => new RichPropertyType(t).sortKey(db));
         typeKeys.sort(sortKeyComparator((x) => x));
-        return [this.type.type, ...typeKeys.flatMap((x) => x)];
+        return ['3', this.type.type, ...typeKeys.flatMap((x) => x)];
     }
   }
 }


### PR DESCRIPTION
Instead, `string | number` should be counted the same as `number | string`.

Fixes #