### PR TITLE
fix: SAM service has incorrect CFN metadata

### DIFF
--- a/packages/@aws-cdk/service-spec-importers/src/resource-builder.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/resource-builder.ts
@@ -65,8 +65,9 @@ export class SpecBuilder {
 
   private allocateService(resourceTypeName: string, resourceTypeNameSeparator = '::') {
     const parts = resourceTypeName.split(resourceTypeNameSeparator);
+    const cloudFormationNamespace = `${parts[0]}${resourceTypeNameSeparator}${parts[1]}`;
 
-    // Name hack for legacy reasons
+    // Name hack for legacy reasons (only affects names, not cloudFormationNamespace)
     if (parts[0] === 'AWS' && parts[1] === 'Serverless') {
       parts[1] = 'SAM';
     }
@@ -74,7 +75,6 @@ export class SpecBuilder {
     const name = `${parts[0]}-${parts[1]}`.toLowerCase();
     const capitalized = parts[1];
     const shortName = capitalized.toLowerCase();
-    const cloudFormationNamespace = `${parts[0]}${resourceTypeNameSeparator}${parts[1]}`;
 
     const existing = this.db.lookup('service', 'name', 'equals', name);
 

--- a/packages/@aws-cdk/service-spec-importers/test/sam-resources.test.ts
+++ b/packages/@aws-cdk/service-spec-importers/test/sam-resources.test.ts
@@ -102,4 +102,13 @@ test('import SAM types by recognizing the Type field that accepts a constant', (
   expect(type).toBeTruthy();
 
   db.lookup('resource', 'cloudFormationType', 'equals', 'AWS::Serverless::OtherThing').only();
+
+  const service = db.all('service');
+  expect(service).toEqual([
+    expect.objectContaining({
+      name: 'aws-sam',
+      capitalized: 'SAM',
+      cloudFormationNamespace: 'AWS::Serverless',
+    }),
+  ]);
 });


### PR DESCRIPTION
The service had `cloudFormationNamespace = 'AWS::SAM'` instead of `AWS::Serverless`.
