### PR TITLE
feat(service-spec-importer): support sources via cli

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -131,10 +131,10 @@ const serviceSpecSchemaTask = serviceSpecImporters.addTask('gen-schemas', {
 
 serviceSpecImporters.compileTask.prependSpawn(serviceSpecSchemaTask);
 
-const buildDb = serviceSpecImporters.tasks.addTask('build:db', {
-  exec: 'ts-node src/cli/import-db --force',
+serviceSpecImporters.tasks.addTask('build:db', {
+  exec: 'ts-node src/cli/import-db',
+  receiveArgs: true,
 });
-serviceSpecImporters.postCompileTask.spawn(buildDb);
 serviceSpecImporters.tasks.addTask('analyze:db', {
   exec: 'ts-node src/cli/analyze-db',
   receiveArgs: true,

--- a/packages/@aws-cdk/service-spec-importers/.projen/tasks.json
+++ b/packages/@aws-cdk/service-spec-importers/.projen/tasks.json
@@ -34,7 +34,8 @@
       "name": "build:db",
       "steps": [
         {
-          "exec": "ts-node src/cli/import-db --force"
+          "exec": "ts-node src/cli/import-db",
+          "receiveArgs": true
         }
       ]
     },
@@ -166,12 +167,7 @@
     },
     "post-compile": {
       "name": "post-compile",
-      "description": "Runs after successful compilation",
-      "steps": [
-        {
-          "spawn": "build:db"
-        }
-      ]
+      "description": "Runs after successful compilation"
     },
     "pre-compile": {
       "name": "pre-compile",

--- a/packages/@aws-cdk/service-spec-importers/README.md
+++ b/packages/@aws-cdk/service-spec-importers/README.md
@@ -42,7 +42,8 @@ Arguments:
   database                         The database file (default: "db.json")
 
 Options:
-  -i, --input <database>           Load an existing database as base, imported sources are additive.
+  -s, --source <definition...>     Import sources into the database. Use the format <source>:<path> to define sources.
+  -l, --load <database>            Load an existing database as base, imported sources become additive
   -c, --gzip                       Compress the database file using gzip
   -f, --force                      Force overwriting an existing file (default: false)
   -d, --debug                      Print additional debug output during import (default: false)
@@ -50,3 +51,39 @@ Options:
   -v, --validate                   Validate imported sources and fail if any data is invalid (default: false)
   -h, --help                       display help for command
 ````
+
+## Sources
+
+| CLI source name     | DatabaseBuilder method                  | Path parameter                                                                  |
+| ------------------- | --------------------------------------- | ------------------------------------------------------------------------------- |
+| `cfnSchemaDir`      | `importCloudFormationRegistryResources` | Directory of structure `<region>/<resource>.json`                               |
+| `samSchema`         | `importSamJsonSchema`                   | SAM Registry Schema file                                                        |
+| `cfnSpecDir`        | `importCloudFormationResourceSpec`      | Directory structure containing a patch set `<region>/000_cloudformation/*.json` |
+| `samSpec`           | `importSamResourceSpec`                 | SAM Resource Specification file file                                            |
+| `cfnDocs`           | `importCloudFormationDocs`              | CloudFormation Documentation file file                                          |
+| `statefulResources` | `importStatefulResources`               | Stateful Resources file                                                         |
+| `cannedMetrics`     | `importCannedMetrics`                   | CloudWatch Console Service Directory file                                       |
+
+### CloudFormation Registry Schema
+
+CLI: `cfnSchemaDir`\
+Code: `importCloudFormationRegistryResources(schemaDir: string)`
+
+Import (modern) CloudFormation Registry Resources from a directory structure.
+The directory MUST contain a directory for per region, each containing a Registry Schema file per resource.
+
+```txt
+CloudFormationSchema/
+├─ us-east-1/
+│  ├─ aws-s3-bucket.json
+├─ eu-west-1/
+│  ├─ aws-s3-bucket.json
+```
+
+### SAM Registry Schema
+
+CLI: `samSchema`\
+Code: `importSamJsonSchema(filePath: string)`
+
+Import the (modern) JSON schema spec from SAM.
+Path to a single file containing a SAM Registry Schema.


### PR DESCRIPTION
The previous PR #635  removed the `FullDatabase` from the `service-spec-importer` package, making the CLI effectively useless since it would never import anything.

Fixing this by adding a simple CLI interface for sources.