### PR TITLE
fix(service-spec-importer): bump version

### DIFF
--- a/packages/@aws-cdk/service-spec-importers/README.md
+++ b/packages/@aws-cdk/service-spec-importers/README.md
@@ -70,7 +70,7 @@ CLI: `cfnSchemaDir`\
 Code: `importCloudFormationRegistryResources(schemaDir: string)`
 
 Import (modern) CloudFormation Registry Resources from a directory structure.
-The directory MUST contain a directory for per region, each containing a Registry Schema file per resource.
+The directory MUST contain a directory for per region, each containing a registry schema file per resource.
 
 ```txt
 CloudFormationSchema/


### PR DESCRIPTION
Noop change to force bump the version of the package to 0.0.1 because aws/aws-cdk cannot deal with 0.0.0 version.