### PR TITLE
fix: deprecated properties not recorded

### DIFF
--- a/packages/@aws-cdk/service-spec-importers/src/importers/import-cloudformation-registry.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/importers/import-cloudformation-registry.ts
@@ -44,7 +44,9 @@ export function importCloudFormationRegistryResource(options: LoadCloudFormation
   // AWS::CloudFront::ContinuousDeploymentPolicy recently introduced a change where they're marking deprecatedProperties
   // as `/definitions/<Type>/properties/<Prop>` instead of `/properties/<Prop1>/<Prop2>/<Prop3>`. Ignore those, as it's
   // out-of-spec
-  const deprecatedProperties = (resource.deprecatedProperties ?? []).filter((p) => p.startsWith('/properties/'));
+  const deprecatedProperties = (resource.deprecatedProperties ?? [])
+    .filter((p) => p.startsWith('/properties/'))
+    .map(simplePropNameFromJsonPtr);
   resourceBuilder.markDeprecatedProperties(...deprecatedProperties);
 
   // Mark everything 'readOnlyProperties` as attributes. However, in the old spec it is possible


### PR DESCRIPTION
In #646 we made a hotpatch to survive incorrectly specified deprecated properties, but made a mistake which removed all deprecation information from the DB.

Fix that.
