### PR TITLE
feat(aws-service-spec): provide a sync function to load the service spec

### DIFF
--- a/packages/@aws-cdk/aws-service-spec/src/index.ts
+++ b/packages/@aws-cdk/aws-service-spec/src/index.ts
@@ -1,15 +1,26 @@
-import { promises as fs } from 'node:fs';
+import { promises as fs, readFileSync } from 'node:fs';
 import * as path from 'node:path';
 import { gunzipSync } from 'node:zlib';
 import { emptyDatabase, SpecDatabase } from '@aws-cdk/service-spec-types';
 
 const DB_COMPRESSED = 'db.json.gz';
+const DB_PATH = path.join(__dirname, '..', DB_COMPRESSED);
 
 /**
  * Load the provided built-in database
  */
 export async function loadAwsServiceSpec(): Promise<SpecDatabase> {
-  const spec = await fs.readFile(path.join(__dirname, '..', DB_COMPRESSED));
+  return loadBufferIntoDatabase(await fs.readFile(DB_PATH));
+}
+
+/**
+ * Synchronously load the provided built-in database
+ */
+export function loadAwsServiceSpecSync(): SpecDatabase {
+  return loadBufferIntoDatabase(readFileSync(DB_PATH));
+}
+
+function loadBufferIntoDatabase(spec: Buffer): SpecDatabase {
   const db = emptyDatabase();
   db.load(JSON.parse(gunzipSync(spec).toString('utf-8')));
   return db;


### PR DESCRIPTION
In some situation we need to access the spec in a synchronous context. This provides a convenience helper to load the spec. It's already possible to do it, but each usage would need it's own implementation.