### PR TITLE
fix(importers): `required` can never be set to `false`

### DIFF
--- a/packages/@aws-cdk/service-spec-importers/src/importers/import-cloudformation-registry.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/importers/import-cloudformation-registry.ts
@@ -77,7 +77,7 @@ export function importCloudFormationRegistryResource(options: LoadCloudFormation
         target.setProperty(name, {
           type,
           documentation: descriptionOf(resolvedSchema),
-          required: ifTrue(required.has(name)),
+          required: required.has(name),
           defaultValue: describeDefault(resolvedSchema),
         });
       });
@@ -346,10 +346,6 @@ export function importCloudFormationRegistryResource(options: LoadCloudFormation
       report.reportFailure('interpreting', x);
     }
   }
-}
-
-function ifTrue(x: boolean | undefined) {
-  return x ? x : undefined;
 }
 
 function descriptionOf(x: jsonschema.ConcreteSchema) {

--- a/packages/@aws-cdk/service-spec-importers/test/double-import.test.ts
+++ b/packages/@aws-cdk/service-spec-importers/test/double-import.test.ts
@@ -134,6 +134,23 @@ test('importing attributes of incompatible types leads to previousTypes', () => 
   );
 });
 
+test('required property can be made optional', () => {
+  const resource = importBoth({
+    spec: {
+      Properties: {
+        Prop1: { PrimitiveType: 'Integer', Required: true, UpdateType: 'Mutable' },
+      },
+    },
+    registry: {
+      properties: {
+        Prop1: { type: 'string' },
+      },
+    },
+  });
+
+  expect(resource.properties.Prop1.required).toBeUndefined();
+});
+
 test('a prop+attr of the same name will not be overwritten', () => {
   const resource = importBoth({
     spec: {


### PR DESCRIPTION
Before merging, the CloudFormation registry importer tried to not emit superfluous fields into the db. So it would not emit `required: false` since the default value of `required` is already `false`.

When we started merging, that lack of emitting meant that any existing value of `required: true` would never be overwritten with `required: undefined` (because `undefined` isn't a value!).

Change this to have the importer always emit `requied: true|false`, so we can correctly update the requiredness of this property.

The merging code itself takes care of canonicalizing `required: false` to removing the property from the data structure, after merging.
