### PR TITLE
fix(aws-service-spec): scrutinies missing for some policy document properties

### DIFF
--- a/packages/@aws-cdk/aws-service-spec/build/scrutinies.ts
+++ b/packages/@aws-cdk/aws-service-spec/build/scrutinies.ts
@@ -3,6 +3,7 @@ import {
   PropertyScrutinyType,
   Resource,
   ResourceScrutinyType,
+  RichPropertyType,
   RichSpecDatabase,
   SpecDatabase,
 } from '@aws-cdk/service-spec-types';
@@ -125,9 +126,9 @@ function isIamType(typeName: string) {
  */
 function isPolicyDocumentProperty(propertyName: string, property: Property) {
   const nameContainsPolicy = propertyName.indexOf('Policy') > -1;
-  const isJson = property.type.type === 'json';
+  const jsonType = new RichPropertyType({ type: 'json' });
 
-  return nameContainsPolicy && isJson;
+  return nameContainsPolicy && jsonType.assignableTo(property.type);
 }
 
 /**

--- a/packages/@aws-cdk/service-spec-types/src/types/resource.ts
+++ b/packages/@aws-cdk/service-spec-types/src/types/resource.ts
@@ -495,6 +495,19 @@ export class RichPropertyType {
   }
 
   /**
+   * Whether the current type is assignable to the RHS type.
+   *
+   * This is the same as normal equality, except when the RHS type is a union and the LHS is not a union.
+   */
+  public assignableTo(rhs: PropertyType): boolean {
+    if (this.type.type != 'union' && rhs.type === 'union') {
+      return rhs.types.some((t) => this.equals(t));
+    }
+
+    return this.equals(rhs);
+  }
+
+  /**
    * Return a version of this type, but with all type unions in a regularized order
    */
   public normalize(db: SpecDatabase): RichPropertyType {

--- a/packages/@aws-cdk/service-spec-types/src/types/resource.ts
+++ b/packages/@aws-cdk/service-spec-types/src/types/resource.ts
@@ -497,14 +497,20 @@ export class RichPropertyType {
   /**
    * Whether the current type is assignable to the RHS type.
    *
-   * This is the same as normal equality, except when the RHS type is a union and the LHS is not a union.
+   * This is means every type member of the LHS must be present in the RHS type
    */
   public assignableTo(rhs: PropertyType): boolean {
-    if (this.type.type != 'union' && rhs.type === 'union') {
-      return rhs.types.some((t) => this.equals(t));
+    const extractMembers = (type: PropertyType): PropertyType[] => (type.type == 'union' ? type.types : [type]);
+    const asRichType = (type: PropertyType): RichPropertyType => new RichPropertyType(type);
+
+    const rhsMembers = extractMembers(rhs);
+    for (const lhsMember of extractMembers(this.type).map(asRichType)) {
+      if (!rhsMembers.some((type) => lhsMember.equals(type))) {
+        return false;
+      }
     }
 
-    return this.equals(rhs);
+    return true;
   }
 
   /**

--- a/packages/@aws-cdk/service-spec-types/test/resource.test.ts
+++ b/packages/@aws-cdk/service-spec-types/test/resource.test.ts
@@ -1,0 +1,50 @@
+import { ArrayType, MapType, PropertyType, RichPropertyType, TypeUnion } from '../lib';
+
+const numberType: PropertyType = renderable({ type: 'number' }, () => 'number');
+const stringType: PropertyType = renderable({ type: 'string' }, () => 'string');
+const jsonType: PropertyType = renderable({ type: 'json' }, () => 'json');
+const arrayType: <E extends PropertyType>(e: E) => ArrayType<E> = (element) =>
+  renderable({ type: 'array', element }, () => `Array<${element}>`);
+const mapType: <E extends PropertyType>(e: E) => MapType<E> = (element) =>
+  renderable({ type: 'map', element }, () => `Map<${element}>`);
+const union: (...e: PropertyType[]) => TypeUnion<PropertyType> = (...types) =>
+  renderable({ type: 'union', types }, () => `[${types.join(' | ')}]`);
+
+describe('RichPropertyType', () => {
+  describe('assignableTo', () => {
+    test.each<[PropertyType, PropertyType, boolean]>([
+      // Primitives
+      [stringType, numberType, false],
+      [jsonType, jsonType, true],
+      [numberType, numberType, true],
+
+      // Arrays
+      [jsonType, arrayType(numberType), false],
+      [arrayType(numberType), jsonType, false],
+      [arrayType(stringType), arrayType(numberType), false],
+      [arrayType(numberType), arrayType(numberType), true],
+
+      // Maps
+      [jsonType, mapType(numberType), false],
+      [mapType(numberType), jsonType, false],
+      [mapType(stringType), mapType(numberType), false],
+      [mapType(numberType), mapType(numberType), true],
+      [mapType(numberType), mapType(numberType), true],
+
+      // Unions
+      [union(numberType, stringType), stringType, true],
+      [union(numberType, stringType), numberType, true],
+      [union(numberType, stringType), union(stringType, numberType), true],
+      [union(numberType, stringType, jsonType), union(stringType, jsonType), true],
+      [union(numberType), union(stringType, jsonType), false],
+      [numberType, union(numberType, jsonType), false],
+    ])('%s := %s | assignable: %s', (lhs: PropertyType, rhs: PropertyType, isAssignable: boolean) => {
+      expect(new RichPropertyType(rhs).assignableTo(lhs)).toBe(isAssignable);
+    });
+  });
+});
+
+function renderable<T>(thing: T, toString: () => string): T {
+  (thing as any).toString = toString;
+  return thing;
+}


### PR DESCRIPTION
We are checking if a property is a policy document in order to decide if it is scrutinizable or  not.
This check used to check if the property type was `json`.
However more complex types can also be used for policy documents.

This PR changes to check to test if  `json` is assignable to the property type.
In practice this means the property type can be a union that contains the `json` type.