### PR TITLE
fix: handle `{}` types

### DIFF
--- a/packages/@aws-cdk/service-spec-importers/schemas/CloudFormationRegistryResource.schema.json
+++ b/packages/@aws-cdk/service-spec-importers/schemas/CloudFormationRegistryResource.schema.json
@@ -393,8 +393,15 @@
       "type": "object"
     },
     "jsonschema.AnyType": {
-      "const": true,
-      "type": "boolean"
+      "anyOf": [
+        {
+          "const": true,
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/jsonschema.EmptyObject"
+        }
+      ]
     },
     "jsonschema.Boolean": {
       "additionalProperties": false,
@@ -445,6 +452,12 @@
           "$ref": "#/definitions/jsonschema.AnyType"
         }
       ]
+    },
+    "jsonschema.EmptyObject": {
+      "additionalProperties": {
+        "not": {}
+      },
+      "type": "object"
     },
     "jsonschema.MapLikeObject": {
       "additionalProperties": false,

--- a/packages/@aws-cdk/service-spec-importers/schemas/SamTemplateSchema.schema.json
+++ b/packages/@aws-cdk/service-spec-importers/schemas/SamTemplateSchema.schema.json
@@ -55,8 +55,15 @@
       "type": "object"
     },
     "jsonschema.AnyType": {
-      "const": true,
-      "type": "boolean"
+      "anyOf": [
+        {
+          "const": true,
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/jsonschema.EmptyObject"
+        }
+      ]
     },
     "jsonschema.Boolean": {
       "additionalProperties": false,
@@ -107,6 +114,12 @@
           "$ref": "#/definitions/jsonschema.AnyType"
         }
       ]
+    },
+    "jsonschema.EmptyObject": {
+      "additionalProperties": {
+        "not": {}
+      },
+      "type": "object"
     },
     "jsonschema.MapLikeObject": {
       "additionalProperties": false,

--- a/packages/@aws-cdk/service-spec-importers/src/types/registry-schema/JsonSchema.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/types/registry-schema/JsonSchema.ts
@@ -11,10 +11,16 @@ export namespace jsonschema {
 
   export type ConcreteSingletonSchema = Object | String | SchemaArray | Boolean | Number | Null | AnyType;
 
-  export type AnyType = true;
+  export type AnyType = true | EmptyObject;
+
+  export type EmptyObject = Record<string, never>;
 
   export function isAnyType(x: Schema): x is AnyType {
-    return x === true;
+    return x === true || isEmptyObject(x);
+  }
+
+  function isEmptyObject(x: any) {
+    return x && typeof x === 'object' && !Array.isArray(x) && Object.keys(x).length === 0;
   }
 
   export interface Annotatable {

--- a/packages/@aws-cdk/service-spec-importers/test/cloudformation-registry.test.ts
+++ b/packages/@aws-cdk/service-spec-importers/test/cloudformation-registry.test.ts
@@ -83,3 +83,22 @@ test('type definitions in deprecated properties do not fail', () => {
 
   // THEN: no failure
 });
+
+test('empty objects are treated as "any"', () => {
+  importCloudFormationRegistryResource({
+    db,
+    report,
+    resource: {
+      typeName: 'AWS::Some::Type',
+      description: 'resource with PrimaryIdentifier',
+      properties: {
+        id: { type: 'string' },
+        data: {},
+      },
+    },
+  });
+
+  // THEN:
+  const resource = db.lookup('resource', 'cloudFormationType', 'equals', 'AWS::Some::Type').only();
+  expect(resource.properties.data.type).toEqual({ type: 'json' });
+});


### PR DESCRIPTION
According to the JSON Schema spec, `{}` should be treated as the `any` type.
