### PR TITLE
chore: don't diff db on main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,7 @@ jobs:
     permissions: {}
     env:
       CI: "true"
+    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -114,7 +115,7 @@ jobs:
       pull-requests: write
     env:
       CI: "true"
-    if: "!(needs.build.outputs.self_mutation_happened)"
+    if: "!(needs.build.outputs.self_mutation_happened) && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target')"
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/projenrc/diff-db.ts
+++ b/projenrc/diff-db.ts
@@ -49,6 +49,7 @@ export class DiffDb extends pj.Component {
       runsOn: this.workflowRunsOn,
       env: { CI: 'true' },
       permissions: {},
+      if: "github.event_name == 'pull_request' || github.event_name == 'pull_request_target'",
       steps: [
         {
           name: 'Checkout',
@@ -83,7 +84,7 @@ export class DiffDb extends pj.Component {
   private diffDatabase() {
     this.workflow.addJob('diff-db', {
       needs: ['build', 'base-database'],
-      if: '!(needs.build.outputs.self_mutation_happened)',
+      if: "!(needs.build.outputs.self_mutation_happened) && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target')",
       runsOn: this.workflowRunsOn,
       env: { CI: 'true' },
       permissions: {


### PR DESCRIPTION
Makes the currently "failing" build on main pass by bypassing the `diff-db` job that is not useful on `main`.
With this we can actually see if everything is alright on main by looking at the status of the latest commit.

<img width="615" alt="image" src="https://github.com/cdklabs/awscdk-service-spec/assets/379814/9c7d6683-e747-4809-9244-a5f300faf223">
