### PR TITLE
chore: set repository url

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -10,6 +10,7 @@ const workflowRunsOn = [
 const repo = new YarnMonorepo({
   name: 'awscdk-service-spec',
   description: "Monorepo for the AWS CDK's service spec",
+  repository: 'https://github.com/cdklabs/awscdk-service-spec',
 
   defaultReleaseBranch: 'main',
   devDeps: [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "awscdk-service-spec",
   "description": "Monorepo for the AWS CDK's service spec",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cdklabs/awscdk-service-spec"
+  },
   "scripts": {
     "build": "npx projen build",
     "clobber": "npx projen clobber",

--- a/packages/@aws-cdk/aws-service-spec/package.json
+++ b/packages/@aws-cdk/aws-service-spec/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@aws-cdk/aws-service-spec",
   "description": "A specification of built-in AWS resources",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cdklabs/awscdk-service-spec",
+    "directory": "packages/@aws-cdk/aws-service-spec"
+  },
   "scripts": {
     "build": "npx projen build",
     "build:db": "npx projen build:db",

--- a/packages/@aws-cdk/service-spec-importers/package.json
+++ b/packages/@aws-cdk/service-spec-importers/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@aws-cdk/service-spec-importers",
   "description": "Import service sources into a service model database",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cdklabs/awscdk-service-spec",
+    "directory": "packages/@aws-cdk/service-spec-importers"
+  },
   "bin": {
     "analyze-db": "bin/analyze-db",
     "diff-db": "bin/diff-db",

--- a/packages/@aws-cdk/service-spec-types/package.json
+++ b/packages/@aws-cdk/service-spec-types/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@aws-cdk/service-spec-types",
   "description": "Types for CloudFormation Service Specifications",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cdklabs/awscdk-service-spec",
+    "directory": "packages/@aws-cdk/service-spec-types"
+  },
   "scripts": {
     "build": "npx projen build",
     "bump": "npx projen bump",

--- a/packages/@cdklabs/tskb/package.json
+++ b/packages/@cdklabs/tskb/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@cdklabs/tskb",
   "description": "Using TypeScript as a knowledge base",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cdklabs/awscdk-service-spec",
+    "directory": "packages/@cdklabs/tskb"
+  },
   "scripts": {
     "build": "npx projen build",
     "bump": "npx projen bump",

--- a/packages/@cdklabs/typewriter/package.json
+++ b/packages/@cdklabs/typewriter/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@cdklabs/typewriter",
   "description": "Write typed code for jsii",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cdklabs/awscdk-service-spec",
+    "directory": "packages/@cdklabs/typewriter"
+  },
   "scripts": {
     "build": "npx projen build",
     "bump": "npx projen bump",


### PR DESCRIPTION
This will ensure that all the published NPM packages correctly link back
to this repository. Currently, this information is missing.
