### PR TITLE
chore(download-file): set no cache headers & print sha256 of downloaded file

### DIFF
--- a/scripts/download.task.js
+++ b/scripts/download.task.js
@@ -11,8 +11,18 @@ const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sources-'));
 const tmpDest = path.join(tmpDir, 'data');
 const tmpExtract = path.join(tmpDir, 'extract');
 
+
+const reqHeaders = new Headers();
+reqHeaders.append('pragma', 'no-cache');
+reqHeaders.append('cache-control', 'no-cache');
+
+var reqOptions = {
+  method: 'GET',
+  headers: reqHeaders,
+};
+
 const file = fs.createWriteStream(tmpDest);
-fetch(url).then((res) => {
+fetch(url, reqOptions).then((res) => {
   res.body.pipe(file);
   file
     .on('finish', () => {

--- a/scripts/download.task.js
+++ b/scripts/download.task.js
@@ -20,9 +20,11 @@ fetch(url).then((res) => {
       console.log('Download completed');
       
       // Print a hash of the downloaded file that can be used for inspection
-      child_process.spawnSync('sha256sum', [tmpDest], {
+      console.log('SHA 256:');
+      child_process.spawnSync('shasum', ['-a', '256', tmpDest], {
         cwd: process.cwd(),
-      });      
+        stdio: 'inherit',
+      });
 
       if (shouldExtract) {
         fs.mkdirSync(tmpExtract, { recursive: true });

--- a/scripts/download.task.js
+++ b/scripts/download.task.js
@@ -18,6 +18,11 @@ fetch(url).then((res) => {
     .on('finish', () => {
       file.close();
       console.log('Download completed');
+      
+      // Print a hash of the downloaded file that can be used for inspection
+      child_process.spawnSync('sha256sum', [tmpDest], {
+        cwd: process.cwd(),
+      });      
 
       if (shouldExtract) {
         fs.mkdirSync(tmpExtract, { recursive: true });


### PR DESCRIPTION
We always want to download the latest version. The additional headers might encourage hosting services to provide the latest files.
Improves debugging for file downloads.