### PR TITLE
fix(service-spec): patch old `PolicyMap` definition back in for `ResilienceHub`

### DIFF
--- a/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/index.ts
+++ b/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/index.ts
@@ -23,6 +23,7 @@ import './elasticsearch';
 import './iot1click';
 import './opensearch';
 import './rds';
+import './resiliencehub';
 import './s3';
 import './sagemaker';
 import './wafv2';

--- a/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/resiliencehub.ts
+++ b/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/resiliencehub.ts
@@ -1,0 +1,19 @@
+import { forResource, registerServicePatches, replaceDefinition } from './core';
+import { patching } from '@aws-cdk/service-spec-importers';
+
+registerServicePatches(
+  forResource('AWS::ResilienceHub::ResiliencyPolicy', (lens) => {
+    const reason = patching.Reason.upstreamTypeNameChange();
+    replaceDefinition(
+      'PolicyMap',
+      {
+        type: 'object',
+        patternProperties: {
+          '.*{1,8}': { $ref: '#/definitions/FailurePolicy' },
+        },
+        additionalProperties: false,
+      },
+      reason,
+    )(lens);
+  }),
+);


### PR DESCRIPTION

For ResilienceHub, added AZ, Hardware, Software, and Region into their PolicyMap as keys. We are reverting this because Maven builds fail with JSII in awscdk and since this was the only change to ResilienceHub, the assumption is this caused the build failures.

Fixes #