### PR TITLE
chore: update verbiage for service patch reason for AWS::Bedrock::KnowledgeBase `StorageConfiguration`

### DIFF
--- a/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/bedrock.ts
+++ b/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/bedrock.ts
@@ -4,7 +4,7 @@ import { patching } from '@aws-cdk/service-spec-importers';
 registerServicePatches(
   forResource('AWS::Bedrock::KnowledgeBase', (lens) => {
     const reason = patching.Reason.sourceIssue(
-      'StorageConfiguration on AWS::Bedrock::KnowledgeBase resource is being dropped while building source model db due to error while importing "oneOf" union type',
+      'StorageConfiguration on AWS::Bedrock::KnowledgeBase resource is being dropped while building source model db due to error importing "oneOf" union type',
     );
     replaceDefinition(
       'StorageConfiguration',


### PR DESCRIPTION
Updated verbiage for service patch reason for AWS::Bedrock::KnowledgeBase `StorageConfiguration`. This PR is an attempt at forcing the publish workflows to succeed after reverting a breaking change in projen.