### PR TITLE
fix(typewriter): export property is ignored for `FreeFunctions`

### DIFF
--- a/packages/@cdklabs/typewriter/src/renderer/typescript.ts
+++ b/packages/@cdklabs/typewriter/src/renderer/typescript.ts
@@ -1,5 +1,5 @@
 import { Renderer } from './base';
-import { CallableDeclaration, isCallableDeclaration } from '../callable';
+import { FreeFunction, isCallableDeclaration } from '../callable';
 import { ClassType } from '../class';
 import { Documented } from '../documented';
 import {
@@ -411,11 +411,11 @@ export class TypeScriptRenderer extends Renderer {
     throw new Error(`Symbol ${sym} (in ${sym.scope}) not visible from ${this.scopes[0]} (missing import?)`);
   }
 
-  protected renderFunction(func: CallableDeclaration) {
+  protected renderFunction(func: FreeFunction) {
     this.renderDocs(func);
     this.emit(`// @ts-ignore TS6133\n`);
 
-    this.emit(`function ${func.name}`);
+    this.emit(`${func.exported ? 'export ' : ''}function ${func.name}`);
     this.renderParameters(func.parameters);
     if (func.returnType) {
       this.emit(': ');

--- a/packages/@cdklabs/typewriter/test/callable.test.ts
+++ b/packages/@cdklabs/typewriter/test/callable.test.ts
@@ -1,0 +1,27 @@
+import { TypeScriptRenderer, Module, FreeFunction, code } from '../src';
+
+const renderer = new TypeScriptRenderer();
+let scope: Module;
+
+beforeEach(() => {
+  scope = new Module('typewriter.test');
+});
+
+describe('free functions', () => {
+  test('can export a free function', () => {
+    const fn = new FreeFunction(scope, {
+      name: 'freefunction',
+      export: true,
+    });
+
+    fn.addBody(code.comment('test comment'));
+
+    expect(renderer.render(scope)).toMatchInlineSnapshot(`
+      "/* eslint-disable prettier/prettier,max-len */
+      // @ts-ignore TS6133
+      export function freefunction(): void {
+        // test comment
+      }"
+    `);
+  });
+});


### PR DESCRIPTION
The `export` property is ignored when rendering a `FreeFunction`. We currently just render the `FreeFunction` without considering if the function should be exported: https://github.com/cdklabs/awscdk-service-spec/blob/4ec0db49148eff5bcbec446a5cded986f063c70b/packages/%40cdklabs/typewriter/src/renderer/typescript.ts#L418

This PR updates the `renderFunction` function to accept a `FreeFunction` type allowing us to check the value of the `export` property. If `export` is true then an export modifier is added in front of the function definition.