### PR TITLE
feat: add attributes with same name as properties

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -123,6 +123,7 @@ const serviceSpecSchemaTask = serviceSpecImporters.addTask('gen-schemas', {
     'StatefulResources',
     'SamTemplateSchema',
     'CloudWatchConsoleServiceDirectory',
+    'GetAttAllowList',
   ].map((typeName: string) => ({
     exec: [
       'ts-json-schema-generator',

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Sources are read in this order:
 | Patches | Handwritten [patches](https://github.com/cdklabs/awscdk-service-spec/tree/main/sources/CloudFormationResourceSpecification/us-east-1/000_cloudformation) are applied to these data sources to correct historical data quality issues with the vended specification | Manual |
 | Registry Schema | This is the new [CloudFormation Resource Provider Schema](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resource-type-schemas.html), replacing the old Resource Spec. It is more expressive than the old spec. Imported in order: `us-east-1`, `us-east-2`, `us-west-2`. | Daily |
 | SAM JSON Schema | This is the newer version of the unofficial [GoFormation](https://github.com/awslabs/goformation) SAM specification, expressed in JSON Schema. | Daily |
-| Patches | Coded [patches](https://github.com/cdklabs/awscdk-service-spec/tree/rix0rrr-patch-1/packages/%40aws-cdk/service-spec-importers/src/patches) are applied to the JSON Schemas to correct for schema inconsistencies | Manual |
+| Patches | Coded [patches](https://github.com/cdklabs/awscdk-service-spec/tree/main/packages/%40aws-cdk/service-spec-importers/src/patches) are applied to the JSON Schemas to correct for schema inconsistencies | Manual |
 | GetAtt AllowList | A static list of attributes with the same name as properties | Manual |
 | CloudFormation Docs | A JSON rendering of the AWS CloudFormation Resource Reference. | Weekly |
 | Stateful Resources | An import of a single configuration file of [cfn-lint](https://github.com/aws-cloudformation/cfn-lint), containing resources that should be considered stateful | Weekly |

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Source of truth for CDK code generation.
 ## Data Sources
 
 The data is read iteratively from various sources. Information from later sources adds on to, or replaces, information
-from older sources. 
+from older sources.
 
 * **Properties are added**: new properties are added into existing resources and type definitions. Existing properties (and attributes)
   will never be removed.
@@ -30,11 +30,12 @@ Sources are read in this order:
 | What | Description | Updates |
 |------|-------------|--------------------
 | Resource Spec | This is the original [CloudFormation Resource Specification](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html), which is being replaced by the Registry Schema. Imported in order from `us-east-1`, `us-west-2`. | Frozen at version `144.0.0` (Oct 13, 2023). |
-| SAM Resource Spec | This is the unofficial SAM resource spec as voluntarily maintained by the [GoFormation](https://github.com/awslabs/goformation) project | Daily | 
-| Patches | Handwritten [patches](https://github.com/cdklabs/awscdk-service-spec/tree/main/sources/CloudFormationResourceSpecification/us-east-1/000_cloudformation) are applied to these data sources to correct historical data quality issues with the vended specification | Manual | 
+| SAM Resource Spec | This is the unofficial SAM resource spec as voluntarily maintained by the [GoFormation](https://github.com/awslabs/goformation) project | Daily |
+| Patches | Handwritten [patches](https://github.com/cdklabs/awscdk-service-spec/tree/main/sources/CloudFormationResourceSpecification/us-east-1/000_cloudformation) are applied to these data sources to correct historical data quality issues with the vended specification | Manual |
 | Registry Schema | This is the new [CloudFormation Resource Provider Schema](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resource-type-schemas.html), replacing the old Resource Spec. It is more expressive than the old spec. Imported in order: `us-east-1`, `us-east-2`, `us-west-2`. | Daily |
 | SAM JSON Schema | This is the newer version of the unofficial [GoFormation](https://github.com/awslabs/goformation) SAM specification, expressed in JSON Schema. | Daily |
-| Patches | Coded [patches](https://github.com/cdklabs/awscdk-service-spec/tree/rix0rrr-patch-1/packages/%40aws-cdk/service-spec-importers/src/patches) are applied to the JSON Schemas to correct for schema inconsistencies | Manual | 
+| Patches | Coded [patches](https://github.com/cdklabs/awscdk-service-spec/tree/rix0rrr-patch-1/packages/%40aws-cdk/service-spec-importers/src/patches) are applied to the JSON Schemas to correct for schema inconsistencies | Manual |
+| GetAtt AllowList | A static list of attributes with the same name as properties | Manual |
 | CloudFormation Docs | A JSON rendering of the AWS CloudFormation Resource Reference. | Weekly |
 | Stateful Resources | An import of a single configuration file of [cfn-lint](https://github.com/aws-cloudformation/cfn-lint), containing resources that should be considered stateful | Weekly |
 | Canned Metrics | An import of an inventory of metrics for various resource types, built by the AWS CloudWatch team for their console | Manual |

--- a/packages/@aws-cdk/aws-service-spec/build/full-database.ts
+++ b/packages/@aws-cdk/aws-service-spec/build/full-database.ts
@@ -20,7 +20,7 @@ export class FullDatabase extends DatabaseBuilder {
       .importSamJsonSchema(path.join(SOURCES, 'SAMSpec/sam.schema.json'), patchSamTemplateSpec)
       .importCloudFormationDocs(path.join(SOURCES, 'CloudFormationDocumentation/CloudFormationDocumentation.json'))
       .importStatefulResources(path.join(SOURCES, 'StatefulResources/StatefulResources.json'))
-      .importGetAttAllowList(path.join(SOURCES, 'GetAttAllowlist/GetAttAllowlist.json'))
+      .importGetAttAllowList(path.join(SOURCES, 'CloudFormationGetAttAllowList/gettatt-allowlist.json'))
       .importCannedMetrics(
         path.join(SOURCES, 'CloudWatchConsoleServiceDirectory/CloudWatchConsoleServiceDirectory.json'),
       )

--- a/packages/@aws-cdk/aws-service-spec/build/full-database.ts
+++ b/packages/@aws-cdk/aws-service-spec/build/full-database.ts
@@ -20,6 +20,7 @@ export class FullDatabase extends DatabaseBuilder {
       .importSamJsonSchema(path.join(SOURCES, 'SAMSpec/sam.schema.json'), patchSamTemplateSpec)
       .importCloudFormationDocs(path.join(SOURCES, 'CloudFormationDocumentation/CloudFormationDocumentation.json'))
       .importStatefulResources(path.join(SOURCES, 'StatefulResources/StatefulResources.json'))
+      .importGetAttAllowList(path.join(SOURCES, 'GetAttAllowlist/GetAttAllowlist.json'))
       .importCannedMetrics(
         path.join(SOURCES, 'CloudWatchConsoleServiceDirectory/CloudWatchConsoleServiceDirectory.json'),
       )

--- a/packages/@aws-cdk/service-spec-importers/.projen/tasks.json
+++ b/packages/@aws-cdk/service-spec-importers/.projen/tasks.json
@@ -145,6 +145,9 @@
         },
         {
           "exec": "ts-json-schema-generator --tsconfig tsconfig.json --type CloudWatchConsoleServiceDirectory --out schemas/CloudWatchConsoleServiceDirectory.schema.json"
+        },
+        {
+          "exec": "ts-json-schema-generator --tsconfig tsconfig.json --type GetAttAllowList --out schemas/GetAttAllowList.schema.json"
         }
       ]
     },

--- a/packages/@aws-cdk/service-spec-importers/README.md
+++ b/packages/@aws-cdk/service-spec-importers/README.md
@@ -22,6 +22,9 @@ new DatabaseBuilder(db, options)
   // Import (legacy) SAM Resource Specification from a directory structure containing a patch set: *.json
   .importSamResourceSpec('data/SAMResourceSpecification/')
 
+  // Import GetAtt'able attributes with the same name as properties
+  .importGetAttAllowList('data/GetAttAllowlist/GetAttAllowlist.json')
+
   // Import various model enhancements
   .importCloudFormationDocs('data/CloudFormationDocumentation.json')
   .importStatefulResources('data/StatefulResources/StatefulResources.json')

--- a/packages/@aws-cdk/service-spec-importers/schemas/GetAttAllowList.schema.json
+++ b/packages/@aws-cdk/service-spec-importers/schemas/GetAttAllowList.schema.json
@@ -1,0 +1,16 @@
+{
+  "$ref": "#/definitions/GetAttAllowList",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "GetAttAllowList": {
+      "additionalProperties": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "description": "Maps a resource type to a list of properties that are also attributes",
+      "type": "object"
+    }
+  }
+}

--- a/packages/@aws-cdk/service-spec-importers/src/db-builder.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/db-builder.ts
@@ -3,6 +3,7 @@ import { assertSuccess, Result } from '@cdklabs/tskb';
 import { importCannedMetrics } from './importers/import-canned-metrics';
 import { importCloudFormationDocumentation } from './importers/import-cloudformation-docs';
 import { importCloudFormationRegistryResource } from './importers/import-cloudformation-registry';
+import { importGetAttAllowList } from './importers/import-getatt-allowlist';
 import { ResourceSpecImporter, SAMSpecImporter } from './importers/import-resource-spec';
 import { SamResources } from './importers/import-sam';
 import { importStatefulResources } from './importers/import-stateful-resources';
@@ -12,6 +13,7 @@ import {
   loadDefaultCloudWatchConsoleServiceDirectory,
   loadDefaultResourceSpecification,
   loadDefaultStatefulResources,
+  loadGetAttAllowList,
   LoadResult,
   loadSamSchema,
   loadSamSpec,
@@ -175,6 +177,17 @@ export class DatabaseBuilder {
         report,
       );
       importCannedMetrics(db, cloudWatchServiceDirectory, report);
+    });
+  }
+
+  /**
+   * Import the GetAtt allowlist
+   */
+  public importGetAttAllowList(specFilePath: string) {
+    return this.addSourceImporter(async (db, report) => {
+      const allowListSpec = this.loadResult(await loadGetAttAllowList(specFilePath, this.options), report);
+
+      importGetAttAllowList(db, allowListSpec);
     });
   }
 

--- a/packages/@aws-cdk/service-spec-importers/src/importers/import-getatt-allowlist.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/importers/import-getatt-allowlist.ts
@@ -1,0 +1,28 @@
+import { SpecDatabase } from '@aws-cdk/service-spec-types';
+import { GetAttAllowList } from '../types';
+
+/**
+ * From the given allowlist, turn the given properties into attributes
+ */
+export function importGetAttAllowList(db: SpecDatabase, allowList: GetAttAllowList) {
+  for (const [resourceType, propNames] of Object.entries(allowList)) {
+    const resource = db.lookup('resource', 'cloudFormationType', 'equals', resourceType).only();
+
+    for (const propName of propNames) {
+      if (resource.attributes[propName]) {
+        // Already exists
+        continue;
+      }
+
+      if (!resource.properties[propName]) {
+        // No such property
+        continue;
+      }
+
+      resource.attributes[propName] = {
+        documentation: resource.properties[propName].documentation,
+        type: resource.properties[propName].type,
+      };
+    }
+  }
+}

--- a/packages/@aws-cdk/service-spec-importers/src/loaders/index.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/loaders/index.ts
@@ -6,3 +6,4 @@ export * from './load-stateful-resources';
 export * from './load-sam-schema';
 export * from './load-sam-spec';
 export * from './load-cloudwatch-console-service-directory';
+export * from './load-getatt-allowlist';

--- a/packages/@aws-cdk/service-spec-importers/src/loaders/load-getatt-allowlist.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/loaders/load-getatt-allowlist.ts
@@ -1,0 +1,16 @@
+import { assertSuccess } from '@cdklabs/tskb';
+import { Loader, LoadResult, LoadSourceOptions } from './loader';
+import { GetAttAllowList } from '../types';
+
+export async function loadGetAttAllowList(
+  filePath: string,
+  options: LoadSourceOptions = {},
+): Promise<LoadResult<GetAttAllowList>> {
+  const loader = await Loader.fromSchemaFile<GetAttAllowList>('GetAttAllowList.schema.json', {
+    mustValidate: options.validate,
+  });
+
+  const result = await loader.loadFile(filePath);
+  assertSuccess(result);
+  return result;
+}

--- a/packages/@aws-cdk/service-spec-importers/src/types/getatt-allowlist/getatt-allowlist.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/types/getatt-allowlist/getatt-allowlist.ts
@@ -1,0 +1,6 @@
+/**
+ * Maps a resource type to a list of properties that are also attributes
+ */
+export interface GetAttAllowList {
+  [resourceType: string]: string[];
+}

--- a/packages/@aws-cdk/service-spec-importers/src/types/index.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/types/index.ts
@@ -5,3 +5,4 @@ export * from './resource-specification/resource-spec';
 export * from './cloudformation-docs/CloudFormationDocumentation';
 export * from './stateful-resources/StatefulResources';
 export * from './cloudwatch-console-service-directory/CloudWatchConsoleServiceDirectory';
+export * from './getatt-allowlist/getatt-allowlist';

--- a/packages/@aws-cdk/service-spec-importers/test/getatt-allowlist.test.ts
+++ b/packages/@aws-cdk/service-spec-importers/test/getatt-allowlist.test.ts
@@ -1,0 +1,28 @@
+import { emptyDatabase } from '@aws-cdk/service-spec-types';
+import { importGetAttAllowList } from '../src/importers/import-getatt-allowlist';
+
+let db: ReturnType<typeof emptyDatabase>;
+beforeEach(() => {
+  db = emptyDatabase();
+
+  // Put a resource in the database
+  db.allocate('resource', {
+    cloudFormationType: 'AWS::Some::Type',
+    attributes: {},
+    name: 'Type',
+    properties: {
+      MyProp: { type: { type: 'string' } },
+    },
+  });
+});
+
+test('mark resource types as stateful', () => {
+  // WHEN
+  importGetAttAllowList(db, {
+    'AWS::Some::Type': ['MyProp'],
+  });
+
+  // THEN
+  const res = db.lookup('resource', 'cloudFormationType', 'equals', 'AWS::Some::Type')[0];
+  expect(res?.attributes.MyProp).toBeDefined();
+});

--- a/sources/CloudFormationGetAttAllowList/README.md
+++ b/sources/CloudFormationGetAttAllowList/README.md
@@ -1,0 +1,20 @@
+# Summary
+
+This directory contains properties that are `{ Fn::GetAtt }`able in CloudFormation, in addition to the
+`readOnlyProperties` indicated by the CloudFormation Registry Schema (CloudFormation also calls these "attributes").
+
+All of the properties in this exception list are both configurable as well as retrievable via `GetAtt`; it would not be
+correct to classify them as `readOnlyProperties`, hence we have an additional list of attributes that have the same
+name as configurable properties.
+
+# Motivation
+
+The CloudFormation Registry Schema is intended as a generic Control Plane protocol, usable by any orchestration engine
+(CloudFormation, Terraform, ...); exactly which properties are `GetAtt`able *in addition* to the `readOnlyProperties` is
+a CloudFormation-the-orchestrator-specific detail, and hence is not encoded into the Registry Schema files.
+
+That is why we need a separate list for full fidelity.
+
+CloudFormation is currently not accepting new resources where `GetAtt`-able attributes have the same name as properties;
+this list is only for backwards compatibility with non-registry resources. It is therefore unlikely to change often, if
+ever, so we feel safe committing it here.

--- a/sources/CloudFormationGetAttAllowList/gettatt-allowlist.json
+++ b/sources/CloudFormationGetAttAllowList/gettatt-allowlist.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c7aabd25bd71c5c290d571267a3a8026651cd3323563338fcadc30555ded165
+size 4815

--- a/sources/CloudFormationGetAttAllowList/gettatt-allowlist.json
+++ b/sources/CloudFormationGetAttAllowList/gettatt-allowlist.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5c7aabd25bd71c5c290d571267a3a8026651cd3323563338fcadc30555ded165
-size 4815
+oid sha256:cab7dd7caf81734a86ace67afaabe2316730c953601cb33320e49e20f94f5014
+size 4748


### PR DESCRIPTION
Add an allowlist to mark those properties.

All of the properties in this exception list are both configurable as well as retrievable via `GetAtt`; it would not be correct to classify them as `readOnlyProperties`, hence we have an additional list of attributes that have the same name as configurable properties.

The CloudFormation Registry Schema is intended as a generic Control Plane protocol, usable by any orchestration engine (CloudFormation, Terraform, ...); exactly which properties are `GetAtt`able *in addition* to the `readOnlyProperties` is a
CloudFormation-the-orchestrator-specific detail, and hence is not encoded into the Registry Schema files.

That is why we need a separate list for full fidelity.

CloudFormation is currently not accepting new resources where `GetAtt`-able attributes have the same name as properties; this list is only for backwards compatibility with non-registry resources. It is therefore unlikely to change often, if ever, so we feel safe committing it here.
