### PR TITLE
chore: patch for AWS::SecurityLake::Subscriber `Source`

### DIFF
--- a/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/index.ts
+++ b/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/index.ts
@@ -28,3 +28,4 @@ import './resiliencehub';
 import './s3';
 import './sagemaker';
 import './wafv2';
+import './securitylake';

--- a/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/securitylake.ts
+++ b/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/securitylake.ts
@@ -1,0 +1,26 @@
+import { patching } from '@aws-cdk/service-spec-importers';
+import { forResource, registerServicePatches, replaceDefinition } from './core';
+
+registerServicePatches(
+  forResource('AWS::SecurityLake::Subscriber', (lens) => {
+    const reason = patching.Reason.sourceIssue(
+      'Sources array on AWS::SecruityLake::Subscriber is being dropped from final service spec db',
+    );
+    replaceDefinition(
+      'Source',
+      {
+        type: 'object',
+        properties : {
+          AwsLogSource : {
+            $ref : "#/definitions/AwsLogSource"
+          },
+          CustomLogSource : {
+            $ref : "#/definitions/CustomLogSource"
+          },
+        },
+        additionalProperties : false,
+      },
+      reason,
+    )(lens);
+  })
+);

--- a/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/securitylake.ts
+++ b/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/securitylake.ts
@@ -4,7 +4,7 @@ import { forResource, registerServicePatches, replaceDefinition } from './core';
 registerServicePatches(
   forResource('AWS::SecurityLake::Subscriber', (lens) => {
     const reason = patching.Reason.sourceIssue(
-      'Sources array on AWS::SecruityLake::Subscriber is being dropped from final service spec db',
+      'Sources array on AWS::SecruityLake::Subscriber is being dropped from final service spec db due to error producing Source type',
     );
     replaceDefinition(
       'Source',


### PR DESCRIPTION
The `Sources` property that is part of `AWS::SecurityLake::Subscriber` resource is being dropped due to errors importing the `Source` type. Since `Sources` is an array of `Source` elements, `Sources` is dropped from the final db. This PR fixes the schema format of `Source` to prevent errors while importing. The database diff below shows that the `Sources` property will be added. This [CR](https://github.com/cdklabs/awscdk-service-spec/pull/1118) shows when the `Sources` property was removed but can be a reference to what we should expect to see in the database diff for `Sources`.