### PR TITLE
chore: patch quicksight dataset property

### DIFF
--- a/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/index.ts
+++ b/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/index.ts
@@ -23,6 +23,7 @@ import './dms';
 import './elasticsearch';
 import './iot1click';
 import './opensearch';
+import './quicksight';
 import './rds';
 import './resiliencehub';
 import './s3';

--- a/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/quicksight.ts
+++ b/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/quicksight.ts
@@ -1,0 +1,25 @@
+import { patching } from '@aws-cdk/service-spec-importers';
+import { forResource, registerServicePatches, replaceDefinition } from './core';
+
+registerServicePatches(
+  forResource('AWS::QuickSight::DataSet', (lens) => {
+    const reason = patching.Reason.sourceIssue(
+      'RefreshConfiguration property is marked as optional unintentionally.',
+    );
+    replaceDefinition(
+      'DataSetRefreshProperties',
+      {
+        "type" : "object",
+        "description" : "<p>The refresh properties of a dataset.</p>",
+        "properties" : {
+          "RefreshConfiguration" : {
+            "$ref" : "#/definitions/RefreshConfiguration"
+          }
+        },
+        "required" : [ "RefreshConfiguration" ],
+        "additionalProperties" : false
+      },
+      reason,
+    )(lens);
+  })
+);

--- a/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/quicksight.ts
+++ b/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/quicksight.ts
@@ -9,15 +9,15 @@ registerServicePatches(
     replaceDefinition(
       'DataSetRefreshProperties',
       {
-        "type" : "object",
-        "description" : "<p>The refresh properties of a dataset.</p>",
-        "properties" : {
-          "RefreshConfiguration" : {
-            "$ref" : "#/definitions/RefreshConfiguration"
+        type: "object",
+        description: "<p>The refresh properties of a dataset.</p>",
+        properties: {
+          RefreshConfiguration: {
+            "$ref": "#/definitions/RefreshConfiguration"
           }
         },
-        "required" : [ "RefreshConfiguration" ],
-        "additionalProperties" : false
+        required: [ "RefreshConfiguration" ],
+        additionalProperties: false
       },
       reason,
     )(lens);


### PR DESCRIPTION
RefreshConfiguration is marked as optional incorrectly by QuickSight team. Updating it back by a temporary patch until their team fixed it.