### PR TITLE
fix(iotfleetwise): add patch to fix the schema definition of the resource DecoderManifest

### DIFF
--- a/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/index.ts
+++ b/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/index.ts
@@ -30,3 +30,4 @@ import './s3';
 import './sagemaker';
 import './wafv2';
 import './securitylake';
+import './iotfleetwise';

--- a/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/iotfleetwise.ts
+++ b/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/iotfleetwise.ts
@@ -1,0 +1,56 @@
+import { forResource, registerServicePatches, replaceResourceProperty } from './core';
+import { patching } from '@aws-cdk/service-spec-importers';
+
+/**
+ * Fix the AWS::IoTFleetWise::DecoderManifest schema. The uploaded schema does not match the CFN docs
+ * where property NetworkInterfaces definition refers to the non-exist CustomDecodingNetworkInterface type
+ * and property SignalDecoders definition refers to the non-exist CustomDecodingSignalDecoder type.
+ * This patch should be removed once the schema got updated.
+ */
+registerServicePatches(
+  forResource('AWS::IoTFleetWise::DecoderManifest', (lens) => {
+    replaceResourceProperty(
+      'SignalDecoders',
+      {
+        type: 'array',
+        minItems: 1,
+        maxItems: 500,
+        insertionOrder: false,
+        items: {
+          oneOf: [
+            {
+              $ref: '#/definitions/CanSignalDecoder',
+            },
+            {
+              $ref: '#/definitions/ObdSignalDecoder',
+            },
+          ],
+        },
+      },
+      patching.Reason.sourceIssue('Remove the wrong reference to the existing definition CustomDecodingSignalDecoder'),
+    )(lens);
+
+    replaceResourceProperty(
+      'NetworkInterfaces',
+      {
+        type: 'array',
+        minItems: 1,
+        maxItems: 500,
+        insertionOrder: false,
+        items: {
+          oneOf: [
+            {
+              $ref: '#/definitions/CanNetworkInterface',
+            },
+            {
+              $ref: '#/definitions/ObdNetworkInterface',
+            },
+          ],
+        },
+      },
+      patching.Reason.sourceIssue(
+        'Remove the wrong reference to the existing definition CustomDecodingNetworkInterface',
+      ),
+    )(lens);
+  }),
+);


### PR DESCRIPTION
Fx the schema for resource AWS::IoTFleetWise::DecoderManifest to remove the reference to non-exist definitions CustomDecodingSignalDecoder, and CustomDecodingNetworkInterface