### PR TITLE
chore: fail downloading sources on http status code != `200`

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -227,6 +227,8 @@ new SingleSource(repo, {
   dir: 'sources/SAMSpec',
   source: 'https://raw.githubusercontent.com/awslabs/goformation/master/schema/sam.schema.json',
 });
+
+// https://github.com/aws-cloudformation/cfn-lint/pull/3257
 new SingleSource(repo, {
   name: 'stateful-resources',
   dir: 'sources/StatefulResources',

--- a/scripts/download.task.js
+++ b/scripts/download.task.js
@@ -23,10 +23,15 @@ var reqOptions = {
 
 const file = fs.createWriteStream(tmpDest);
 fetch(url, reqOptions).then((res) => {
+
+  if (res.status !== 200) {
+    throw new Error(`Http Status ${res.status}`);
+  }
+
   res.body.pipe(file);
   file
     .on('finish', () => {
-      file.close();
+      file.close();  
       console.log('Download completed');
       
       // Print a hash of the downloaded file that can be used for inspection
@@ -60,6 +65,9 @@ fetch(url, reqOptions).then((res) => {
     })
     .on('error', function (error) {
       fs.rmSync(tmpDir, { recursive: true, force: true });
-      console.error(`Download failed: ${error.message}`);
-    });
+      throw error;
+    });  
+}).catch(e => {
+  console.error(`Download failed: ${e.message}`);
+  process.exit(1);
 });


### PR DESCRIPTION
Our [feat(sources): update stateful-resources](https://github.com/cdklabs/awscdk-service-spec/pull/1106) PR is currently failing to build:

```console
👾 build » compile » build:db | ts-node build/build-db.ts
FAIL


SyntaxError: Unexpected non-whitespace character after JSON at position 3
```

This happens because the `StatefulResources.json` file got updated with an invalid value. Our workflow updates this with the contents of `StatefulResources.json` coming from [cfn-lint](https://github.com/aws-cloudformation/cfn-lint). However, In https://github.com/aws-cloudformation/cfn-lint/pull/3257, this file was [removed](https://raw.githubusercontent.com/aws-cloudformation/cfn-lint/main/src/cfnlint/data/AdditionalSpecs/StatefulResources.json) (it is now inlined inside the python file that was using it). This results in the file being updated with the string `404: Not Found` - which is not a valid JSON.

In this scenario, we shouldn't have even created the PR, but rather fail during the workflow execution. We didn't because our workflow ignores http status codes when downloading a source, this PR fixes that. 

### Notes

- This replaces build failure with workflow execution failure, but we still need to figure out how to handle the file removal.