### PR TITLE
feat(sources): patch b2bi partnership property

### DIFF
--- a/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/b2bi-partnership.ts
+++ b/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/b2bi-partnership.ts
@@ -1,0 +1,17 @@
+import { patching } from '@aws-cdk/service-spec-importers';
+import { forResource, registerServicePatches, replaceDefinition } from './core';
+
+registerServicePatches(
+  forResource('AWS::B2BI::Partnership', (lens) => {
+    const reason = patching.Reason.sourceIssue(
+      'Capabilities property is marked as required by service team. Revert it to prevent regression',
+    );
+    replaceDefinition(
+      'B2BIPartnernshipProperties',
+      {
+        required:[ "Email", "Name", "ProfileId" ]
+      },
+      reason,
+    )(lens);
+  })
+);

--- a/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/index.ts
+++ b/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/index.ts
@@ -31,3 +31,4 @@ import './sagemaker';
 import './wafv2';
 import './securitylake';
 import './iotfleetwise';
+import './b2bi-partnership';


### PR DESCRIPTION
Fixing the change in property from required to optional , to prevent any regression for the L1 update release. 
Property `Capabilities` was marked as required under B2BI Partnership schema from `optional` previously, this change is to revert it and mark it as an `optional` property again.