### PR TITLE
fix: properties with embedded anyOf being dropped

### DIFF
--- a/packages/@aws-cdk/service-spec-importers/src/types/registry-schema/JsonSchema.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/types/registry-schema/JsonSchema.ts
@@ -88,7 +88,14 @@ export namespace jsonschema {
    * Determines whether or not the provided schema represents an `anyOf` type operator.
    */
   export function isAnyOf(x: Schema): x is AnyOf<any> {
-    return !isAnyType(x) && 'anyOf' in x;
+    if ('anyOf' in (x as any) && !isAnyType(x)) {
+      for (const elem of (x as RecordLikeObject).anyOf!) {
+        if (!isAnyType(elem) && (isTypeDefined(elem) || isReference(elem))) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   export interface OneOf<S> extends Annotatable {
@@ -161,6 +168,8 @@ export namespace jsonschema {
     readonly properties: ObjectProperties;
     readonly required?: string[];
     readonly oneOf?: (CommonTypeCombinatorFields | RecordLikeObject)[];
+    readonly anyOf?: (CommonTypeCombinatorFields | RecordLikeObject)[];
+
     /**
      * FIXME: should be required but some service teams have omitted it.
      */

--- a/packages/@aws-cdk/service-spec-importers/test/property-conversion.test.ts
+++ b/packages/@aws-cdk/service-spec-importers/test/property-conversion.test.ts
@@ -292,6 +292,67 @@ test('oneOf containing a list of "required" properties and a required property',
   expect(Object.keys(resource.properties)).toContain('DataSourceConfiguration');
 });
 
+test('anyOf containing a list of subproperties', async () => {
+  importCloudFormationRegistryResource({
+    db,
+    report,
+    resource: {
+      typeName : "AWS::DMS::DataProvider",
+      description : "Resource schema for AWS::DMS::DataProvider",
+      properties : {
+        Settings : {
+          description : "The property identifies the exact type of settings for the data provider.",
+          type : "object",
+          properties : {
+            PostgreSqlSettings : {
+              description : "PostgreSqlSettings property identifier.",
+              type : "object",
+              properties : {
+                ServerName : {
+                  type : "string"
+                },
+              },
+            },
+            MySqlSettings : {
+              description : "MySqlSettings property identifier.",
+              type : "object",
+              properties : {
+                ServerName : {
+                  "type" : "string"
+                },
+              },
+            },
+            OracleSettings : {
+              description : "OracleSettings property identifier.",
+              type : "object",
+              properties : {
+                ServerName : {
+                  type : "string"
+                },
+              },
+            },
+          },
+          anyOf : [ {
+            required : [ "PostgreSqlSettings" ]
+          }, {
+            required : [ "MySqlSettings" ]
+          }, {
+            required : [ "OracleSettings" ]
+          }, ],
+          additionalProperties : false
+        },
+      }
+    }
+  });
+
+  const resource = db.lookup('resource', 'cloudFormationType', 'equals', 'AWS::DMS::DataProvider').only();
+  const requiredProps = Object.entries(resource.properties)
+    .filter(([_, value]) => value.required)
+    .map(([name, _]) => name);
+  expect(requiredProps.length).toBe(0);
+  expect(Object.keys(resource.properties)).toContain('Settings');
+});
+
 test('oneOf with only a reference', () => {
   importCloudFormationRegistryResource({
     db,


### PR DESCRIPTION
Based off of https://github.com/cdklabs/awscdk-service-spec/pull/1269, which did not actually do anything for `anyOf`.