### PR TITLE
fix: most eslint rules have moved to @stylistic

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -1,6 +1,11 @@
 {
   "dependencies": [
     {
+      "name": "@stylistic/eslint-plugin",
+      "version": "^2",
+      "type": "build"
+    },
+    {
       "name": "@types/node",
       "type": "build"
     },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -19,6 +19,7 @@ const repo = new YarnMonorepo({
     'eslint',
     '@typescript-eslint/parser@^6',
     '@typescript-eslint/eslint-plugin@^6',
+    '@stylistic/eslint-plugin@^2',
     'eslint-plugin-import',
   ],
   vscodeWorkspace: true,

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "projen": "npx projen"
   },
   "devDependencies": {
+    "@stylistic/eslint-plugin": "^2",
     "@types/node": "^18",
     "@typescript-eslint/eslint-plugin": "^6",
     "@typescript-eslint/parser": "^6",

--- a/packages/@cdklabs/typewriter/src/eslint-rules.ts
+++ b/packages/@cdklabs/typewriter/src/eslint-rules.ts
@@ -1,11 +1,11 @@
 /**
  * All Eslint rules that typewriter can disable.
  */
-export enum EsLintRules {
-  COMMA_DANGLE = '@typescript-eslint/comma-dangle',
-  COMMA_SPACING = 'comma-spacing',
-  QUOTE_PROPS = 'quote-props',
-  QUOTES = 'quotes',
-  PRETTIER_PRETTIER = 'prettier/prettier',
-  MAX_LEN = 'max-len',
+export class EsLintRules {
+  public static readonly COMMA_DANGLE = '@stylistic/comma-dangle';
+  public static readonly COMMA_SPACING = '@stylistic/comma-spacing';
+  public static readonly QUOTE_PROPS = '@stylistic/quote-props';
+  public static readonly QUOTES = '@stylistic/quotes';
+  public static readonly PRETTIER_PRETTIER = 'prettier/prettier';
+  public static readonly MAX_LEN = '@stylistic/max-len';
 }

--- a/packages/@cdklabs/typewriter/src/renderer/typescript.ts
+++ b/packages/@cdklabs/typewriter/src/renderer/typescript.ts
@@ -67,11 +67,11 @@ export interface TypeScriptRenderOptions extends RenderOptions {
    *
    * @default: max-len, prettier/prettier
    */
-  disabledEsLintRules?: EsLintRules[];
+  disabledEsLintRules?: string[];
 }
 
 export class TypeScriptRenderer extends Renderer {
-  private disabledEsLintRules: EsLintRules[];
+  private disabledEsLintRules: string[];
   public constructor(options: TypeScriptRenderOptions = {}) {
     super(options);
 

--- a/packages/@cdklabs/typewriter/test/comments.test.ts
+++ b/packages/@cdklabs/typewriter/test/comments.test.ts
@@ -16,7 +16,7 @@ describe('statements', () => {
     fn.addBody(code.comment('test comment'));
 
     expect(renderer.render(scope)).toMatchInlineSnapshot(`
-      "/* eslint-disable prettier/prettier, max-len */
+      "/* eslint-disable prettier/prettier, @stylistic/max-len */
       // @ts-ignore TS6133
       function freeFunction(): void {
         // test comment
@@ -32,7 +32,7 @@ describe('statements', () => {
     fn.addBody(code.commentOn(code.stmt.ret(code.expr.lit(1)), 'test comment'));
 
     expect(renderer.render(scope)).toMatchInlineSnapshot(`
-      "/* eslint-disable prettier/prettier, max-len */
+      "/* eslint-disable prettier/prettier, @stylistic/max-len */
       // @ts-ignore TS6133
       function freeFunction(): void {
         // test comment
@@ -51,7 +51,7 @@ describe('expressions', () => {
     fn.addBody(code.stmt.ret(code.commentOn(code.expr.lit(1), 'test comment')));
 
     expect(renderer.render(scope)).toMatchInlineSnapshot(`
-      "/* eslint-disable prettier/prettier, max-len */
+      "/* eslint-disable prettier/prettier, @stylistic/max-len */
       // @ts-ignore TS6133
       function freeFunction(): void {
         return /* test comment */ 1;
@@ -75,7 +75,7 @@ describe('expressions', () => {
     );
 
     expect(renderer.render(scope)).toMatchInlineSnapshot(`
-      "/* eslint-disable prettier/prettier, max-len */
+      "/* eslint-disable prettier/prettier, @stylistic/max-len */
       // @ts-ignore TS6133
       function freeFunction(): void {
         return ["foo", /* test comment */ "bar", "baz"];
@@ -91,7 +91,7 @@ describe('expressions', () => {
     fn.addBody(code.stmt.ret(code.commentOn($E(code.expr.lit(1)).convertToString(), 'test comment')));
 
     expect(renderer.render(scope)).toMatchInlineSnapshot(`
-      "/* eslint-disable prettier/prettier, max-len */
+      "/* eslint-disable prettier/prettier, @stylistic/max-len */
       // @ts-ignore TS6133
       function freeFunction(): void {
         return /* test comment */ 1.convertToString();

--- a/packages/@cdklabs/typewriter/test/exports.test.ts
+++ b/packages/@cdklabs/typewriter/test/exports.test.ts
@@ -14,7 +14,7 @@ describe('functions', () => {
     });
 
     expect(renderer.render(scope)).toMatchInlineSnapshot(`
-      "/* eslint-disable prettier/prettier, max-len */
+      "/* eslint-disable prettier/prettier, @stylistic/max-len */
       // @ts-ignore TS6133
       function freeFunction(): void;"
     `);
@@ -27,7 +27,7 @@ describe('functions', () => {
     });
 
     expect(renderer.render(scope)).toMatchInlineSnapshot(`
-      "/* eslint-disable prettier/prettier, max-len */
+      "/* eslint-disable prettier/prettier, @stylistic/max-len */
       // @ts-ignore TS6133
       export function freeFunction(): void;"
     `);
@@ -40,7 +40,7 @@ describe('functions', () => {
     });
 
     expect(renderer.render(scope)).toMatchInlineSnapshot(`
-      "/* eslint-disable prettier/prettier, max-len */
+      "/* eslint-disable prettier/prettier, @stylistic/max-len */
       // @ts-ignore TS6133
       function freeFunction(): void;"
     `);

--- a/packages/@cdklabs/typewriter/test/proxy.test.ts
+++ b/packages/@cdklabs/typewriter/test/proxy.test.ts
@@ -17,7 +17,7 @@ describe('expression proxy', () => {
     fn.addBody(code.stmt.ret($E(code.expr.lit(1)).convertToString()));
 
     expect(renderer.render(scope)).toMatchInlineSnapshot(`
-      "/* eslint-disable prettier/prettier, max-len */
+      "/* eslint-disable prettier/prettier, @stylistic/max-len */
       // @ts-ignore TS6133
       function freeFunction(): string {
         return 1.convertToString();

--- a/packages/@cdklabs/typewriter/test/ts-rendering.test.ts
+++ b/packages/@cdklabs/typewriter/test/ts-rendering.test.ts
@@ -10,17 +10,19 @@ beforeEach(() => {
 describe('eslint rules', () => {
   test('prettier/prettier and max-len are disabled by default', () => {
     const renderer = new TypeScriptRenderer();
-    expect(renderer.render(scope)).toMatchInlineSnapshot(`"/* eslint-disable prettier/prettier, max-len */"`);
+    expect(renderer.render(scope)).toMatchInlineSnapshot(
+      `"/* eslint-disable prettier/prettier, @stylistic/max-len */"`,
+    );
   });
 
   test('max-len can be explicitly disabled without disabling prettier/prettier', () => {
     const renderer = new TypeScriptRenderer({ disabledEsLintRules: [EsLintRules.MAX_LEN] });
-    expect(renderer.render(scope)).toMatchInlineSnapshot(`"/* eslint-disable max-len */"`);
+    expect(renderer.render(scope)).toMatchInlineSnapshot(`"/* eslint-disable @stylistic/max-len */"`);
   });
 
   test('A single eslint rule can be disabled', () => {
     const renderer = new TypeScriptRenderer({ disabledEsLintRules: [EsLintRules.COMMA_DANGLE] });
-    expect(renderer.render(scope)).toMatchInlineSnapshot(`"/* eslint-disable @typescript-eslint/comma-dangle */"`);
+    expect(renderer.render(scope)).toMatchInlineSnapshot(`"/* eslint-disable @stylistic/comma-dangle */"`);
   });
 
   test('many eslint rules can be disabled', () => {
@@ -35,7 +37,7 @@ describe('eslint rules', () => {
       ],
     });
     expect(renderer.render(scope)).toMatchInlineSnapshot(
-      `"/* eslint-disable @typescript-eslint/comma-dangle, comma-spacing, max-len, prettier/prettier, quotes, quote-props */"`,
+      `"/* eslint-disable @stylistic/comma-dangle, @stylistic/comma-spacing, @stylistic/max-len, prettier/prettier, @stylistic/quotes, @stylistic/quote-props */"`,
     );
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -797,6 +797,17 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
+"@stylistic/eslint-plugin@^2":
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/@stylistic/eslint-plugin/-/eslint-plugin-2.12.1.tgz#e341beb4e4315084d8be20bceeeda7d8a46f079f"
+  integrity sha512-fubZKIHSPuo07FgRTn6S4Nl0uXPRPYVNpyZzIDGfp7Fny6JjNus6kReLD7NI380JXi4HtUTSOZ34LBuNPO1XLQ==
+  dependencies:
+    "@typescript-eslint/utils" "^8.13.0"
+    eslint-visitor-keys "^4.2.0"
+    espree "^10.3.0"
+    estraverse "^5.3.0"
+    picomatch "^4.0.2"
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.11.tgz#6ee46400685f130e278128c7b38b7e031ff5b2f2"
@@ -1114,7 +1125,7 @@
     "@typescript-eslint/typescript-estree" "6.21.0"
     semver "^7.5.4"
 
-"@typescript-eslint/utils@8.18.1":
+"@typescript-eslint/utils@8.18.1", "@typescript-eslint/utils@^8.13.0":
   version "8.18.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.18.1.tgz#c4199ea23fc823c736e2c96fd07b1f7235fa92d5"
   integrity sha512-8vikiIj2ebrC4WRdcAdDcmnu9Q/MXXwg+STf40BVfT8exDqBCUPdypvzcUPxEqRGKg9ALagZ0UWcYCtn+4W2iQ==
@@ -2588,7 +2599,7 @@ esrecurse@^4.3.0:
   dependencies:
     estraverse "^5.2.0"
 
-estraverse@^5.1.0, estraverse@^5.2.0:
+estraverse@^5.1.0, estraverse@^5.2.0, estraverse@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
@@ -4673,6 +4684,11 @@ picomatch@^2.0.4, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+picomatch@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.2.tgz#77c742931e8f3b8820946c76cd0c1f13730d1dab"
+  integrity sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==
 
 pify@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
ESLint has moved most of it's style-related linter rules to a namespace called `@stylistic`.

Update our built-in linter rules to reference those rules in the new package name, and change the public interface to accept arbitrary strings, instead of an enum from a specific set of rules.
