### PR TITLE
feat: make it possible to print a DB

### DIFF
--- a/packages/@aws-cdk/service-spec-importers/src/diff-fmt.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/diff-fmt.ts
@@ -20,7 +20,7 @@ import { PrintableTree } from './printable-tree';
 const ADDITION = '[+]';
 const UPDATE = '[~]';
 const REMOVAL = '[-]';
-const META_INDENT = 2;
+const META_INDENT = 6;
 
 const [OLD_DB, NEW_DB] = [0, 1];
 
@@ -52,7 +52,7 @@ export class DiffFormatter {
       ),
       listWithCaption(
         'resources',
-        this.dbs[db].follow('hasResource', s).map((e) => this.renderResource(e.entity, db)),
+        this.dbs[db].follow('hasResource', s).map((e) => this.renderResource(e.entity, db).prefix([' '])),
       ),
     ]);
   }
@@ -66,8 +66,8 @@ export class DiffFormatter {
         'resources',
         this.renderMapDiff(
           s.resourceDiff,
-          (r, db) => this.renderResource(r, db),
-          (k, u) => this.renderUpdatedResource(k, u),
+          (r, db) => this.renderResource(r, db).prefix([' ']),
+          (k, u) => this.renderUpdatedResource(k, u).prefix([' ']),
         ),
       ),
     ];
@@ -95,7 +95,7 @@ export class DiffFormatter {
       listWithCaption('attributes', this.renderProperties(r.attributes, db)),
       listWithCaption(
         'types',
-        this.dbs[db].follow('usesType', r).map((e) => this.renderTypeDefinition(e.entity, db)),
+        this.dbs[db].follow('usesType', r).map((e) => this.renderTypeDefinition(e.entity, db).prefix([' '])),
       ),
     ]);
   }
@@ -121,7 +121,7 @@ export class DiffFormatter {
         'types',
         this.renderMapDiff(
           r.typeDefinitionDiff,
-          (t, db) => this.renderTypeDefinition(t, db),
+          (t, db) => this.renderTypeDefinition(t, db).prefix([' ']),
           (k, u) => this.renderUpdatedTypeDefinition(k, u),
         ),
       ),
@@ -177,7 +177,7 @@ export class DiffFormatter {
   }
 
   private renderProperties(ps: Record<string, Property>, db: number): PrintableTree[] {
-    return Object.entries(ps).map(([name, p]) => this.renderProperty(p, db).prefix([`${name}: `]));
+    return Object.entries(ps).map(([name, p]) => this.renderProperty(p, db).prefix([' ', `${name}: `]));
   }
 
   private renderMapDiff<E, U>(

--- a/packages/@aws-cdk/service-spec-importers/src/printable-tree.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/printable-tree.ts
@@ -78,6 +78,14 @@ export class PrintableTree {
     return this;
   }
 
+  /**
+   * Prefix all lines of the tree with the given list of cells.
+   *
+   * The first line will be prefixed with `first`.
+   *
+   * The other lines will be prefixed with `rest` if given, or the length of
+   * `first` in spaces if rest is not given.
+   */
   public prefix(first: string[], rest?: string[]) {
     rest = rest ?? first.map((x) => ' '.repeat(x.length));
 


### PR DESCRIPTION
We used to only render a pretty diff of a spec database.

Make it possible to diff with an empty DB, which is effectively the same as pretty-printing an entire DB.

Update the printing style a little to add more whitespace in places that feel cramped.
