### PR TITLE
fix(batch): add patch to keep the old name of the EksPodProperties type.

### DIFF
--- a/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/batch.ts
+++ b/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/batch.ts
@@ -9,5 +9,6 @@ registerServicePatches(
     renameDefinition('EksHostPath', 'HostPath', reason)(lens);
     renameDefinition('EksContainerResourceRequirements', 'Resources', reason)(lens);
     renameDefinition('EksContainerSecurityContext', 'SecurityContext', reason)(lens);
+    renameDefinition('EksPodProperties', 'PodProperties', reason)(lens);
   }),
 );


### PR DESCRIPTION
Keep the old name of `EksPodProperties` to be `PodProperties`.