### PR TITLE
fix(batch): add patch to keep the old name of the Volumes, and EfsVolumeConfiguration types

### DIFF
--- a/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/batch.ts
+++ b/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/batch.ts
@@ -10,5 +10,7 @@ registerServicePatches(
     renameDefinition('EksContainerResourceRequirements', 'Resources', reason)(lens);
     renameDefinition('EksContainerSecurityContext', 'SecurityContext', reason)(lens);
     renameDefinition('EksPodProperties', 'PodProperties', reason)(lens);
+    renameDefinition('Volume', 'Volumes', reason)(lens);
+    renameDefinition('EFSVolumeConfiguration', 'EfsVolumeConfiguration', reason)(lens);
   }),
 );


### PR DESCRIPTION
add patch to keep the old name of the Volumes, and EfsVolumeConfiguration types.

This PR deletes the Volume, and EFSVolumeConfiguration types.