### PR TITLE
fix: revert adding GlobalClusterEndpoint to readonlyProperty

### DIFF
--- a/sources/CloudFormationSchema/us-west-2/aws-rds-globalcluster.json
+++ b/sources/CloudFormationSchema/us-west-2/aws-rds-globalcluster.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:52c396b4a891537b7786efc4b46d90d9e49ddc6e1306563f7fbadef6244d999d
-size 5498
+oid sha256:211f950b673a73d55f920d8238ba699d1ebce3a4f861dd3f6cb578c38eef7171
+size 5439


### PR DESCRIPTION
In a recent schema change, globalEndpoint property was added to readOnlyPorperties
```
"readOnlyProperties" : [ "/properties/GlobalEndpoint" ],
```

This caused `GlobalEndpoint` property is being removed from RDS GlobalCluster L1. 

Reverting this change for now to continue the release. 