### PR TITLE
fix: manually patch `AWS::DynamoDB::GlobalTable` and `AWS::RDS::GlobalCluster`

### DIFF
--- a/sources/CloudFormationDocumentation/CloudFormationDocumentation.json
+++ b/sources/CloudFormationDocumentation/CloudFormationDocumentation.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:80a124180e21bdf7a02df8357167033fff139a2eccd381394193ad319622cd11
-size 9980726
+oid sha256:be062ecd46de0d92524d20c01743b3ce9ffe3db468a696bd30d4ff98b1b62df8
+size 9980836

--- a/sources/CloudFormationSchema/us-east-1/aws-dynamodb-globaltable.json
+++ b/sources/CloudFormationSchema/us-east-1/aws-dynamodb-globaltable.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:844b5bab54a9b42435f05ea0308098c4c8b612d6ab787437cf241c38d0f0debb
-size 17724
+oid sha256:44adba20d9ad701bd0d42c9ff39bc8c4981b57dc86602304290fb21d2dcbc022
+size 17838

--- a/sources/CloudFormationSchema/us-east-2/aws-dynamodb-globaltable.json
+++ b/sources/CloudFormationSchema/us-east-2/aws-dynamodb-globaltable.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:844b5bab54a9b42435f05ea0308098c4c8b612d6ab787437cf241c38d0f0debb
-size 17724
+oid sha256:44adba20d9ad701bd0d42c9ff39bc8c4981b57dc86602304290fb21d2dcbc022
+size 17838

--- a/sources/CloudFormationSchema/us-west-2/aws-rds-globalcluster.json
+++ b/sources/CloudFormationSchema/us-west-2/aws-rds-globalcluster.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:52c396b4a891537b7786efc4b46d90d9e49ddc6e1306563f7fbadef6244d999d
-size 5498
+oid sha256:211f950b673a73d55f920d8238ba699d1ebce3a4f861dd3f6cb578c38eef7171
+size 5439


### PR DESCRIPTION
This is a direct removal and not a patch to speed things up and release a version. We most likely don't need a permenant patch for these. 