### PR TITLE
fix: patch `AWS::DynamoDB::GlobalTable` and `AWS::RDS::GlobalCluster`

### DIFF
--- a/sources/CloudFormationResourceSpecification/us-east-1/000_cloudformation/950_DynamoDB_GlobalTable_PITR.json
+++ b/sources/CloudFormationResourceSpecification/us-east-1/000_cloudformation/950_DynamoDB_GlobalTable_PITR.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e553fd07b5ff43cec690099c834e23b8bd0ca6b2a5c239f41ab24c0a0079f05
+size 424

--- a/sources/CloudFormationResourceSpecification/us-west-2/000_cloudformation/000_official/950_DynamoDB_GlobalTable_PITR.json
+++ b/sources/CloudFormationResourceSpecification/us-west-2/000_cloudformation/000_official/950_DynamoDB_GlobalTable_PITR.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e553fd07b5ff43cec690099c834e23b8bd0ca6b2a5c239f41ab24c0a0079f05
+size 424

--- a/sources/CloudFormationResourceSpecification/us-west-2/000_cloudformation/000_official/960_RDS_GlobalCluster_GlobalEndpoint.json
+++ b/sources/CloudFormationResourceSpecification/us-west-2/000_cloudformation/000_official/960_RDS_GlobalCluster_GlobalEndpoint.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b1f9ad109c3aeff17563fd58a25180c3cbee89146c28138446ae7ba738920ac
+size 312


### PR DESCRIPTION
- Patch https://github.com/cdklabs/awscdk-service-spec/pull/1631 as it was already reverted by automation.
- Patch PITR for global table.