### PR TITLE
fix(cognito): bring back `id` attribute on `UserPoolDomain`

### DIFF
--- a/sources/CloudFormationSchema/us-east-1/aws-cognito-userpooldomain.json
+++ b/sources/CloudFormationSchema/us-east-1/aws-cognito-userpooldomain.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1dab49b0d769bbeb052583b78f42a68a791ebf54560bca4cfd152d6c631b9028
-size 1914
+oid sha256:80e9953d2fd751542a22cc0ded18697a2075bde54b11cf78e4061f8afec006d3
+size 1932

--- a/sources/CloudFormationSchema/us-east-2/aws-cognito-userpooldomain.json
+++ b/sources/CloudFormationSchema/us-east-2/aws-cognito-userpooldomain.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1dab49b0d769bbeb052583b78f42a68a791ebf54560bca4cfd152d6c631b9028
-size 1914
+oid sha256:80e9953d2fd751542a22cc0ded18697a2075bde54b11cf78e4061f8afec006d3
+size 1932

--- a/sources/CloudFormationSchema/us-west-2/aws-cognito-userpooldomain.json
+++ b/sources/CloudFormationSchema/us-west-2/aws-cognito-userpooldomain.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1dab49b0d769bbeb052583b78f42a68a791ebf54560bca4cfd152d6c631b9028
-size 1914
+oid sha256:80e9953d2fd751542a22cc0ded18697a2075bde54b11cf78e4061f8afec006d3
+size 1932


### PR DESCRIPTION
To fix:

```console
├[~] service aws-cognito
│ └ resources
│    └[~]  resource AWS::Cognito::UserPoolDomain
│       └ attributes
│          └[-] Id: string
```

See https://github.com/aws/aws-cdk/pull/33475