### PR TITLE
fix: patch rds issue

### DIFF
--- a/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/rds.ts
+++ b/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/rds.ts
@@ -9,7 +9,7 @@ registerServicePatches(
   ),
   fp.removeFromReadOnlyProperties(
     'AWS::RDS::GlobalCluster',
-    ['GlobalEndppoint'],
+    ['GlobalEndpoint'],
     patching.Reason.sourceIssue('GlobalEndpoint should not be listed in readOnlyProperties.'),
-  )
+  ),
 );

--- a/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/rds.ts
+++ b/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/rds.ts
@@ -7,4 +7,9 @@ registerServicePatches(
     ['ReadEndpoint'],
     patching.Reason.sourceIssue('ReadEndpoint should be listed in readOnlyProperties.'),
   ),
+  fp.removeFromReadOnlyProperties(
+    'AWS::RDS::GlobalCluster',
+    ['GlobalEndppoint'],
+    patching.Reason.sourceIssue('GlobalEndpoint should not be listed in readOnlyProperties.'),
+  )
 );


### PR DESCRIPTION
https://github.com/cdklabs/awscdk-service-spec/pull/1644

RDS global endpoint is added to readonly property only in `us-west-2` schema. We should patch this change as it will remove `GlobalEndpoint` from a user input properties which is clearly available in CFN documentation https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-globalcluster.html#cfn-rds-globalcluster-globalendpoint