### PR TITLE
fix: correctly generate all properties in oneOf/anyOf schema

### DIFF
--- a/packages/@aws-cdk/service-spec-importers/src/importers/import-cloudformation-registry.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/importers/import-cloudformation-registry.ts
@@ -139,7 +139,9 @@ export function importCloudFormationRegistryResource(options: LoadCloudFormation
             if ((t.title && t.required?.includes(t.title)) || (refName && t.required?.includes(refName))) {
               report.reportFailure(
                 'interpreting',
-                fail(`${propertyName} is a union of objects. Merging into a single type and removing required fields.`),
+                fail(
+                  `${propertyName} is a union of objects. Merging into a single type and removing required fields for oneOf and anyOf.`,
+                ),
               );
               return schemaTypeToModelType(nameHint, resolve({ ...t, required: undefined }), fail);
             }
@@ -211,7 +213,7 @@ export function importCloudFormationRegistryResource(options: LoadCloudFormation
             if (elementName && nextName && elementName === nextName && element.type !== next.type) {
               report.reportFailure(
                 'interpreting',
-                fail(`Invalid schema with property name ${element.title} but types ${element.type} and ${next.type}`),
+                fail(`Invalid schema with property name ${elementName} but types ${element.type} and ${next.type}`),
               );
             }
           }

--- a/packages/@aws-cdk/service-spec-importers/src/importers/import-cloudformation-registry.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/importers/import-cloudformation-registry.ts
@@ -127,7 +127,7 @@ export function importCloudFormationRegistryResource(options: LoadCloudFormation
         // that has the same property name but different types. For simplicity, we do not validate if the types
         // are overlapping. We will add this case to the problem report. An sample schema would be i.e. 
         // foo: { oneOf: [ { properties: { type: ObjectA } }, { properties: { type: ObjectB } }]}
-        validateCombiningSchemaType(inner);
+        validateCombiningSchemaType(inner, fail);
 
         const convertedTypes = inner.map((t) => {
           if (jsonschema.isObject(t) && jsonschema.isRecordLikeObject(t)) {
@@ -195,7 +195,7 @@ export function importCloudFormationRegistryResource(options: LoadCloudFormation
     });
   }
 
-  function validateCombiningSchemaType(schema: jsonschema.ConcreteSchema[]) {
+  function validateCombiningSchemaType(schema: jsonschema.ConcreteSchema[], fail: Fail) {
     schema.forEach((element, index) => {
       if (!jsonschema.isAnyType(element) && !jsonschema.isCombining(element)) {
         schema.slice(index + 1).forEach((next) => {

--- a/packages/@aws-cdk/service-spec-importers/src/importers/import-cloudformation-registry.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/importers/import-cloudformation-registry.ts
@@ -126,7 +126,7 @@ export function importCloudFormationRegistryResource(options: LoadCloudFormation
         const convertedTypes = inner.map((t) => {
           if (jsonschema.isObject(t) && jsonschema.isRecordLikeObject(t)) {
             const refName = jsonschema.resolvedReferenceName(t);
-            if (!refName || (refName && t.required?.includes(refName))) {
+            if ((t.title && t.required?.includes(t.title)) || (refName && t.required?.includes(refName))) {
               return schemaTypeToModelType(nameHint, resolve({ ...t, required: undefined }), fail);
             }
           }

--- a/packages/@aws-cdk/service-spec-importers/src/importers/import-cloudformation-registry.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/importers/import-cloudformation-registry.ts
@@ -125,7 +125,7 @@ export function importCloudFormationRegistryResource(options: LoadCloudFormation
 
         // Validate oneOf and anyOf types schema by validating whether there are two definitions in oneOf/anyOf
         // that has the same property name but different types. For simplicity, we do not validate if the types
-        // are overlapping. We will add this case to the problem report. An sample schema would be i.e. 
+        // are overlapping. We will add this case to the problem report. An sample schema would be i.e.
         // foo: { oneOf: [ { properties: { type: ObjectA } }, { properties: { type: ObjectB } }]}
         validateCombiningSchemaType(inner, fail);
 
@@ -215,10 +215,9 @@ export function importCloudFormationRegistryResource(options: LoadCloudFormation
               );
             }
           }
-        })
+        });
       }
     });
-
   }
 
   function schemaObjectToModelType(nameHint: string, schema: jsonschema.Object, fail: Fail): Result<PropertyType> {

--- a/packages/@aws-cdk/service-spec-importers/src/importers/import-cloudformation-registry.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/importers/import-cloudformation-registry.ts
@@ -125,6 +125,10 @@ export function importCloudFormationRegistryResource(options: LoadCloudFormation
 
         const convertedTypes = inner.map((t) => {
           if (jsonschema.isObject(t) && jsonschema.isRecordLikeObject(t)) {
+            // The item in union type is an object
+            // We need to remove 'required' constraint from the object schema definition as we're dealing
+            // with oneOf/anyOf. Note that we should ONLY remove 'required' when the 'required' constraint
+            // refers to the object itself not the inner properties
             const refName = jsonschema.resolvedReferenceName(t);
             if ((t.title && t.required?.includes(t.title)) || (refName && t.required?.includes(refName))) {
               return schemaTypeToModelType(nameHint, resolve({ ...t, required: undefined }), fail);

--- a/packages/@aws-cdk/service-spec-importers/src/importers/import-cloudformation-registry.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/importers/import-cloudformation-registry.ts
@@ -123,9 +123,12 @@ export function importCloudFormationRegistryResource(options: LoadCloudFormation
           return schemaTypeToModelType(nameHint, jsonschema.setResolvedReference(combinedType, reference), fail);
         }
 
-        const convertedTypes = inner.map((t) => {          
-          if (jsonschema.isObject(t)) {
-            return schemaTypeToModelType(nameHint, resolve({ ...t, required: undefined }), fail);
+        const convertedTypes = inner.map((t) => {
+          if (jsonschema.isObject(t) && jsonschema.isRecordLikeObject(t)) {
+            const refName = jsonschema.resolvedReferenceName(t);
+            if (!refName || (refName && t.required?.includes(refName))) {
+              return schemaTypeToModelType(nameHint, resolve({ ...t, required: undefined }), fail);
+            }
           }
           return schemaTypeToModelType(nameHint, resolve(t), fail);
         });


### PR DESCRIPTION
Schema issue summary: there are two ways of defining oneOf/anyOf schema but semantically they mean the same thing:
 The property item itself is one of multiple object types, where each type references a definition
The property item is a single type that references a definition, and that definition itself is one of multiple types of definitions.

For example, consider the following two schema:
Scenario one: property item itself is one of multiple object types
```
resource: {
      typeName : "AWS::VpcLattice::ResourceConfiguration",
      description: "VpcLattice ResourceConfiguration CFN resource",
      definitions: {
        ResourceConfigurationDefinition: {
          oneOf: [
            {
              additionalProperties: false,
              type: 'object',
              properties: {
                IpResource: {
                  $ref: '#/definitions/IpResource',
                },
              },
              required: ['IpResource'],
            },
            {
              additionalProperties: false,
              type: 'object',
              title: 'ArnResource',
              properties: {
                ArnResource: {
                  $ref: '#/definitions/ArnResource',
                },
              },
              required: ['ArnResource'],
            },
            {
              additionalProperties: false,
              type: 'object',
              title: 'DnsResource',
              properties: {
                DnsResource: {
                  $ref: '#/definitions/DnsResource',
                },
              },
              required: ['DnsResource'],
            },
          ],
        },
        IpResource: {
          minLength: 4,
          type: 'string',
          maxLength: 39,
        },
        PortRange: {
          minLength: 1,
          pattern: '^((\\d{1,5}\\-\\d{1,5})|(\\d+))$',
          type: 'string',
          maxLength: 11,
        },
        DnsResource: {
          additionalProperties: false,
          type: 'object',
          properties: {
            IpAddressType: {
              type: 'string',
              enum: ['IPV4', 'IPV6', 'DUALSTACK'],
            },
            DomainName: {
              minLength: 3,
              type: 'string',
              maxLength: 255,
            },
          },
          required: ['DomainName', 'IpAddressType'],
        },
        ArnResource: {
          pattern: '^arn:[a-z0-9][-.a-z0-9]{0,62}:vpc-lattice:([a-z0-9][-.a-z0-9]{0,62})?:\\d{12}?:[^/].{0,1023}$',
          type: 'string',
          maxLength: 1224,
        },
      },
      properties: {
        ResourceConfigurationDefinition: {
          $ref: '#/definitions/ResourceConfigurationDefinition',
        },
      },
    },
```
And this is scenario two: property item is a single type that references a definition, and that definition itself is one of multiple types of definitions.
```
resource: {
      typeName : "AWS::VpcLattice::ResourceConfiguration",
      description: "VpcLattice ResourceConfiguration CFN resource",
      definitions: {
        IpResource: {
          minLength: 4,
          type: 'string',
          maxLength: 39,
        },
        PortRange: {
          minLength: 1,
          pattern: '^((\\d{1,5}\\-\\d{1,5})|(\\d+))$',
          type: 'string',
          maxLength: 11,
        },
        DnsResource: {
          additionalProperties: false,
          type: 'object',
          properties: {
            IpAddressType: {
              type: 'string',
              enum: ['IPV4', 'IPV6', 'DUALSTACK'],
            },
            DomainName: {
              minLength: 3,
              type: 'string',
              maxLength: 255,
            },
          },
          required: ['DomainName', 'IpAddressType'],
        },
        ArnResource: {
          pattern: '^arn:[a-z0-9][-.a-z0-9]{0,62}:vpc-lattice:([a-z0-9][-.a-z0-9]{0,62})?:\\d{12}?:[^/].{0,1023}$',
          type: 'string',
          maxLength: 1224,
        },
      },
      properties: {
        ResourceConfigurationDefinition: {
          oneOf: [
            {
              additionalProperties: false,
              type: 'object',
              properties: {
                IpResource: {
                  $ref: '#/definitions/IpResource',
                },
              },
              required: ['IpResource'],
            },
            {
              additionalProperties: false,
              type: 'object',
              title: 'ArnResource',
              properties: {
                ArnResource: {
                  $ref: '#/definitions/ArnResource',
                },
              },
              required: ['ArnResource'],
            },
            {
              additionalProperties: false,
              type: 'object',
              title: 'DnsResource',
              properties: {
                DnsResource: {
                  $ref: '#/definitions/DnsResource',
                },
              },
              required: ['DnsResource'],
            },
          ],
          type: 'object',
        },
      },
    },
```
CDK service spec was not able to correctly handle any of the two formats of schema initially. In 2024, CDK team worked on a fix that partially fixed the generation of the first oneOf/anyOf syntax and turned it into an interface containing all properties instead of union types (to maintain backward compatibility) . There are a few resources, i.e. AWS::CloudFormation::LambdaHook and AWS::CloudFormation::GuardHook and AWS::VpcLattice:ResourceConfiguration that uses the second schema format and CDK incorrectly generates only the first value.

The PR attempts to fix the second case where we unify this behaviour to match the first schema format.