### PR TITLE
fix: update @aws-cdk/aws-service-spec dev dependency

### DIFF
--- a/packages/@aws-cdk/aws-service-spec/package.json
+++ b/packages/@aws-cdk/aws-service-spec/package.json
@@ -26,7 +26,7 @@
     "projen": "npx projen"
   },
   "devDependencies": {
-    "@aws-cdk/service-spec-importers": "^0.0.0",
+    "@aws-cdk/service-spec-importers": "0.0.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^18",
     "@typescript-eslint/eslint-plugin": "^8",


### PR DESCRIPTION
## Issue

The release workflow is blocked (https://github.com/cdklabs/awscdk-service-spec/actions/runs/13987488911) due to a recent change in the [cdklabs/cdklabs-projen-project-types](https://github.com/cdklabs/cdklabs-projen-project-types/tree/main) dependency ([PR #832](https://github.com/cdklabs/cdklabs-projen-project-types/pull/832)).

## Change

Set the devDependency `@aws-cdk/service-spec-importers` of `@aws-cdk/aws-service-spec` to the exact version `0.0.0`, as it is a sibling module within the same monorepo.