### PR TITLE
fix: create patch for AWS::RDS::DBInstance CertificateDetails and Endpoint properties

### DIFF
--- a/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/rds.ts
+++ b/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/rds.ts
@@ -1,4 +1,4 @@
-import { addDefinitions, forResource, fp, registerServicePatches, replaceDefinition, replaceDefinitionProperty } from './core';
+import { fp, registerServicePatches } from './core';
 import { patching } from '@aws-cdk/service-spec-importers';
 
 registerServicePatches(

--- a/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/rds.ts
+++ b/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/rds.ts
@@ -1,4 +1,4 @@
-import { fp, registerServicePatches } from './core';
+import { addDefinitions, forResource, fp, registerServicePatches, replaceDefinition, replaceDefinitionProperty } from './core';
 import { patching } from '@aws-cdk/service-spec-importers';
 
 registerServicePatches(
@@ -6,5 +6,10 @@ registerServicePatches(
     'AWS::RDS::DBCluster',
     ['ReadEndpoint'],
     patching.Reason.sourceIssue('ReadEndpoint should be listed in readOnlyProperties.'),
+  ),
+  fp.addReadOnlyProperties(
+    'AWS::RDS::DBInstance',
+    ['CertificateDetails', 'Endpoint'],
+    patching.Reason.sourceIssue('CertificateDetails and Endpoint should be listed in readOnlyProperties. Pending service team confirmation that the removal of these properties is intentional.'),
   ),
 );


### PR DESCRIPTION
This patch addresses the following L1 schema update change:
```
├[~] service aws-rds
│ └ resources
│    └[~]  resource AWS::RDS::DBInstance
│       └ properties
│          ├[-] CertificateDetails: CertificateDetails
│          └[-] Endpoint: Endpoint
