### PR TITLE
fix: create patch for AWS::RDS::DBInstance CertificateDetails and Endpoint properties

### DIFF
--- a/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/rds.ts
+++ b/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/rds.ts
@@ -8,7 +8,7 @@ registerServicePatches(
     patching.Reason.sourceIssue('ReadEndpoint should be listed in readOnlyProperties.'),
   ),
   fp.patchResourceAt<types.CloudFormationRegistryResource['readOnlyProperties']>(
-    'AWS::DMS::ReplicationConfig',
+    'AWS::RDS::DBInstance',
     '/properties/CertificateDetails',
     patching.Reason.sourceIssue('Missing description caused property to be removed in L1 update.'),
     (descriptionAndType = []) => {

--- a/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/rds.ts
+++ b/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/rds.ts
@@ -11,10 +11,11 @@ registerServicePatches(
     'AWS::DMS::ReplicationConfig',
     '/properties/CertificateDetails',
     patching.Reason.sourceIssue('Missing description caused property to be removed in L1 update.'),
-    (descriptionAndType = {}) => {
-      descriptionAndType = {
-        "$ref" : "#/definitions/CertificateDetails",
-        "description" : "The details of the DB instance’s server certificate."
+    (descriptionAndType = []) => {
+      for (const [idx, prop] of descriptionAndType.entries()) {
+        if (prop.startsWith('/description')) {
+          descriptionAndType[idx] = 'The details of the DB instance’s server certificate.';
+        }
       }
       return descriptionAndType;
     },

--- a/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/rds.ts
+++ b/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/rds.ts
@@ -7,4 +7,9 @@ registerServicePatches(
     ['ReadEndpoint'],
     patching.Reason.sourceIssue('ReadEndpoint should be listed in readOnlyProperties.'),
   ),
+  fp.addReadOnlyProperties(
+    'AWS::RDS::DBInstance',
+    ['CertificateDetails', 'Endpoint'],
+    patching.Reason.sourceIssue('CertificateDetails and Endpoint should be listed in readOnlyProperties. Pending service team confirmation that the removal of these properties is intentional.'),
+  ),
 );


### PR DESCRIPTION
This patch addresses the following L1 schema update change:
```
├[~] service aws-rds
│ └ resources
│    └[~]  resource AWS::RDS::DBInstance
│       └ properties
│          ├[-] CertificateDetails: CertificateDetails
│          └[-] Endpoint: Endpoint
