### PR TITLE
fix: add patch for neptune DBSubnetGroup

### DIFF
--- a/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/index.ts
+++ b/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/index.ts
@@ -29,3 +29,4 @@ import './sagemaker';
 import './wafv2';
 import './securitylake';
 import './iotfleetwise';
+import './neptune';

--- a/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/neptune.ts
+++ b/packages/@aws-cdk/aws-service-spec/build/patches/service-patches/neptune.ts
@@ -1,0 +1,10 @@
+import { fp, registerServicePatches } from './core';
+import { patching } from '@aws-cdk/service-spec-importers';
+
+registerServicePatches(
+    fp.addReadOnlyProperties(
+        'AWS::Neptune::DBSubnetGroup',
+        ['Id'],
+        patching.Reason.sourceIssue('Id should be listed in readOnlyProperties.'),
+      ),
+);


### PR DESCRIPTION
Addresses the removal of `Id` in this schema change:

```
├[~] service aws-neptune
│ └ resources
│    └[~]  resource AWS::Neptune::DBSubnetGroup
│       └ attributes
│          └[-] Id: string