### PR TITLE
fix(service-spec): treat evolution of json -> string as a bugfix

### DIFF
--- a/packages/@aws-cdk/service-spec-importers/src/importers/import-cloudformation-registry.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/importers/import-cloudformation-registry.ts
@@ -3,6 +3,7 @@ import { locateFailure, Fail, failure, isFailure, Result, tryCatch, using, ref, 
 import { ProblemReport, ReportAudience } from '../report';
 import { PropertyBagBuilder, SpecBuilder } from '../resource-builder';
 import { unionSchemas } from '../schema-manipulation/unify-schemas';
+import { maybeUnion } from '../type-manipulation';
 import {
   CloudFormationRegistryResource,
   ImplicitJsonSchemaRecord,
@@ -153,7 +154,7 @@ export function importCloudFormationRegistryResource(options: LoadCloudFormation
         const types = convertedTypes.filter(isSuccess);
         removeUnionDuplicates(types);
 
-        return { type: 'union', types };
+        return maybeUnion(types);
       } else if (jsonschema.isAllOf(resolvedSchema)) {
         // FIXME: Do a proper thing here
         const firstResolved = resolvedSchema.allOf[0];

--- a/packages/@aws-cdk/service-spec-importers/src/importers/import-resource-spec.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/importers/import-resource-spec.ts
@@ -1,6 +1,7 @@
 import { PropertyType, SpecDatabase, TypeDefinition } from '@aws-cdk/service-spec-types';
 import { ref } from '@cdklabs/tskb';
 import { PropertyBagBuilder, ResourceBuilder, SpecBuilder } from '../resource-builder';
+import { maybeUnion } from '../type-manipulation';
 import { CloudFormationResourceSpecification, SAMResourceSpecification, resourcespec } from '../types';
 
 //////////////////////////////////////////////////////////////////////
@@ -288,16 +289,5 @@ export class SAMSpecImporter extends ResourceSpecImporterBase<SAMResourceSpecifi
       }
       throw new Error(`Unknown primitive type: ${prim} in resource ${self.resourceName}`);
     }
-  }
-}
-
-function maybeUnion(types: PropertyType[]): PropertyType {
-  switch (types.length) {
-    case 0:
-      throw new Error('Oops, no types');
-    case 1:
-      return types[0];
-    default:
-      return { type: 'union', types };
   }
 }

--- a/packages/@aws-cdk/service-spec-importers/src/type-manipulation.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/type-manipulation.ts
@@ -1,0 +1,12 @@
+import { PropertyType } from '@aws-cdk/service-spec-types';
+
+export function maybeUnion(types: PropertyType[]): PropertyType {
+  switch (types.length) {
+    case 0:
+      throw new Error('Oops, no types');
+    case 1:
+      return types[0];
+    default:
+      return { type: 'union', types };
+  }
+}

--- a/packages/@aws-cdk/service-spec-importers/test/double-import.test.ts
+++ b/packages/@aws-cdk/service-spec-importers/test/double-import.test.ts
@@ -90,6 +90,34 @@ test('importing properties of incompatible types leads to previousTypes', () => 
   );
 });
 
+test('typing first as Json and then String leaves just String and nothing else', () => {
+  // This behavior is an attempt to automatically discriminate between legitimate type evolution
+  // and schema bugfixes (only for very specific cases).
+  const resource = importBoth({
+    spec: {
+      Properties: {
+        Prop1: { PrimitiveType: 'Json', UpdateType: 'Mutable' },
+      },
+    },
+    registry: {
+      properties: {
+        Prop1: { type: 'string' },
+      },
+    },
+  });
+
+  expect(resource.properties.Prop1).toEqual(
+    expect.objectContaining({
+      type: { type: 'string' },
+    } satisfies Partial<Property>),
+  );
+  expect(resource.properties.Prop1).not.toEqual(
+    expect.objectContaining({
+      previousTypes: expect.anything(),
+    } satisfies Partial<Property>),
+  );
+});
+
 test('importing string on top of date-time does nothing', () => {
   const resource = importBoth({
     spec: {

--- a/packages/@aws-cdk/service-spec-importers/test/property-conversion.test.ts
+++ b/packages/@aws-cdk/service-spec-importers/test/property-conversion.test.ts
@@ -410,7 +410,7 @@ test('same property name but different types', async () => {
   expect(Object.keys(resource.properties)).toContain('DataSourceConfiguration');
   const prop = resource.properties?.DataSourceConfiguration;
 
-  const type = db.get('typeDefinition', (prop.type as { types: DefinitionReference[] }).types[0].reference.$ref);
+  const type = db.get('typeDefinition', (prop.type as DefinitionReference).reference.$ref);
   expect(type.name).toEqual('DataSourceConfiguration');
   expect(type.properties.foo.type.type).toBe('array');
 });
@@ -600,9 +600,9 @@ test('oneOf typed objects with one of in properties', async () => {
   const resource = db.lookup('resource', 'cloudFormationType', 'equals', 'AWS::oneOf::Required').only();
   expect(Object.keys(resource.properties)).toContain('ResourceConfigurationDefinition');
   const prop = resource.properties?.ResourceConfigurationDefinition;
-  expect(prop.type.type).toBe('union');
+  expect(prop.type.type).toBe('ref');
 
-  const type = db.get('typeDefinition', (prop.type as { types: DefinitionReference[] }).types[0].reference.$ref);
+  const type = db.get('typeDefinition', (prop.type as DefinitionReference).reference.$ref);
   expect(type.name).toBe('ResourceConfigurationDefinition');
   expect(Object.keys(type.properties).length).toBe(3);
   expect(type.properties.IpResource.required).toBe(undefined);

--- a/packages/@aws-cdk/service-spec-types/src/types/resource.ts
+++ b/packages/@aws-cdk/service-spec-types/src/types/resource.ts
@@ -211,11 +211,7 @@ export class RichTypedField {
     // `json` -> `named type`, or `named type` -> `named type`.  For now I'm
     // wary of destroying too much information; we'll just do the fix specifically
     // for `json` -> `string`.
-    if (
-      type.type === 'string' &&
-      this.field.previousTypes?.length === 1 &&
-      this.field.previousTypes[0].type === 'json'
-    ) {
+    if (type.type === 'string' && this.field.type.type === 'json') {
       this.field.type = type;
       return true;
     }


### PR DESCRIPTION
The type of a property holds a set of `previousTypes`. The reason we hold this type history is because if a CDK Resource property was ever typed as "json", we can never change it to a named type, for backwards compatibility reasons. The L1 code generator for CDK always takes the oldest type that a property advertises and codegens using that.

(In the future it would be possible to generate multiple fields with different types, for example, but we're not currently doing that yet.)

There are two reasons why a property type can change:

- Gradual type refinement (some type that used to be typed as `Json` now gets a named type with accurate field definition)
- Bugfixes (oops! It was never actually an `X` but the schema erroneously advertised it as such)

The reasons for backwards compatibility exist to deal with the first situation, but we sometimes have the second situation.

In https://github.com/aws/aws-cdk/issues/26749, which was the motivation for this change: at some point in the past (in the legacy CFN spec, specifically) the type of `UpdatedBy` was `Json`, but this got changed to `String` later. In fact CloudFormation fails deployment if the value is anything other than a `String`, but our backwards compatibility rules mandate that because this type was at some point in the past `Json`, it shall remain `Json` forever.

Because the backwards compatibility rules are intended to deal with changes of `Json` -> "named type", we add an exception here: if the change is `Json` -> `String`, we assume this is a bugfix change and we don't record the old type.

Fixes https://github.com/aws/aws-cdk/issues/26749

Also changed in this PR:

- I noticed some types were marked as a union with 1 branch. In order to simplify the type detection, I've made it so that these are simplified to just the 1 type itself.