### PR TITLE
fix: invalid attributes and properties remain because of renames

### DIFF
--- a/packages/@aws-cdk/service-spec-importers/src/importers/import-resource-spec.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/importers/import-resource-spec.ts
@@ -53,6 +53,8 @@ abstract class ResourceSpecImporterBase<Spec extends CloudFormationResourceSpeci
     this.handleAttributes(resourceSpec.Attributes ?? {});
 
     this.handleUnusedTypes();
+
+    this.resourceBuilder.commit();
   }
 
   /**
@@ -81,7 +83,7 @@ abstract class ResourceSpecImporterBase<Spec extends CloudFormationResourceSpeci
     const { typeDefinitionBuilder, freshInDb, freshInSession } = this.resourceBuilder.typeDefinitionBuilder(typeName);
 
     if (freshInDb && this.renderingUnusedTypes) {
-      typeDefinitionBuilder.typeDef.mustRenderForBwCompat = true;
+      typeDefinitionBuilder.setFields({ mustRenderForBwCompat: true });
     }
 
     if (freshInSession) {
@@ -89,7 +91,7 @@ abstract class ResourceSpecImporterBase<Spec extends CloudFormationResourceSpeci
       this.recurseProperties(spec.Properties ?? {}, typeDefinitionBuilder);
     }
 
-    return { type: 'ref', reference: ref(typeDefinitionBuilder.typeDef) };
+    return { type: 'ref', reference: ref(typeDefinitionBuilder.commit()) };
   }
 
   protected recurseProperties(

--- a/packages/@aws-cdk/service-spec-importers/test/double-import.test.ts
+++ b/packages/@aws-cdk/service-spec-importers/test/double-import.test.ts
@@ -197,17 +197,18 @@ test('a prop+attr of the same name will not be overwritten', () => {
     },
   });
 
-  expect(resource.attributes.Something).toEqual(
-    expect.objectContaining({
-      type: { type: 'integer' },
-    }),
-  );
-  expect(resource.properties.Something).toEqual(
-    expect.objectContaining({
+  expect({ attribute: resource.attributes.Something }).toEqual({
+    attribute: expect.objectContaining({
       type: { type: 'json' },
-      previousTypes: [{ type: 'string' }],
+      previousTypes: [{ type: 'integer' }],
     }),
-  );
+  });
+
+  expect({ property: resource.properties.Something }).toEqual({
+    property: expect.objectContaining({
+      type: { type: 'string' },
+    }),
+  });
 });
 
 function importBoth(options: {


### PR DESCRIPTION
The `ResourceBuilder` used to mess around moving properties between the mutable property bags of `resource.properties` and `resource.attributes`, which would already contain data from previous versions of the spec.  This could lead to the parsing of a new version of the spec interfering with the result of a parsing of a previous version of the spec.

Instead, we now mutate `candidateProperties` and `candidateAttributes`, and commit the final state to the underlying `Resource` object when we're done.
