### PR TITLE
feat: sanitize primary identifiers

### DIFF
--- a/packages/@aws-cdk/service-spec-importers/test/patches/json-schema-patches.test.ts
+++ b/packages/@aws-cdk/service-spec-importers/test/patches/json-schema-patches.test.ts
@@ -3,6 +3,7 @@ import {
   explodeTypeArray,
   missingTypeObject,
   removeEmptyRequiredArray,
+  sanitizePrimaryIdentifier,
 } from '../../src/patches/json-schema-patches';
 import { patchObject } from '../utils';
 
@@ -228,5 +229,41 @@ describe(missingTypeObject, () => {
         },
       },
     });
+  });
+});
+
+describe(sanitizePrimaryIdentifier, () => {
+  test('does not modify valid primaryIdentifier', () => {
+    const obj = {
+      typeName: 'AWS::Service::Resource',
+      type: 'object',
+      primaryIdentifier: ['/properties/RestApiId', '/properties/SomethingElse'],
+      properties: {
+        valid: {
+          type: 'string',
+        },
+      },
+    };
+
+    const patchedObj = patchObject(obj, sanitizePrimaryIdentifier);
+
+    expect(patchedObj).toEqual(obj);
+  });
+
+  test('does modify affected primaryIdentifier', () => {
+    const obj = {
+      typeName: 'AWS::ApiGateway::RequestValidator',
+      type: 'object',
+      primaryIdentifier: ['/properties/RestApiId', '/properties/ValidatorId'],
+      properties: {
+        valid: {
+          type: 'string',
+        },
+      },
+    };
+
+    const patchedObj = patchObject(obj, sanitizePrimaryIdentifier);
+
+    expect(patchedObj.primaryIdentifier).toEqual(['/properties/ValidatorId']);
   });
 });


### PR DESCRIPTION
There are at least two resource types, `AWS::ApiGateway::RequestValidator` and `AWS::ApiGateway::Model`, whose primary identifiers do not match reality. In the schema, the primary identifier for these resources includes the `RestApiId` attribute. But this attribute is not returned by the CloudFormation intrinsic `Ref` function, and it's not possible to `Fn::GettAtt` it either.

Sanitize the `primaryIdentifier` for these resource types, by removing the `RestApiId` attribute from the array.