### PR TITLE
feat: update CloudWatch Console Service Directory source

### DIFF
--- a/sources/CloudWatchConsoleServiceDirectory/CloudWatchConsoleServiceDirectory.json
+++ b/sources/CloudWatchConsoleServiceDirectory/CloudWatchConsoleServiceDirectory.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:de71bf13edc22bcaee5fdd868d349847a29089ed2b60da4c780f6dcc2bbff614
-size 930079
+oid sha256:046f50fbeddf5f796fc05443ebd4cc16fb213398aa7f5691642cfb56b132e62f
+size 1328176


### PR DESCRIPTION
Manual one-off update of the source, since we haven't done this for a while.