### PR TITLE
feat: new type of statement, to wrap type declarations

### DIFF
--- a/packages/@cdklabs/typewriter/src/renderer/typescript.ts
+++ b/packages/@cdklabs/typewriter/src/renderer/typescript.ts
@@ -51,6 +51,7 @@ import {
   ThrowStatement,
   MonkeyPatchMethod,
   EmptyStatement,
+  TypeDeclarationStatement,
 } from '../statements';
 import { StructType } from '../struct';
 import { ThingSymbol } from '../symbol';
@@ -529,6 +530,9 @@ export class TypeScriptRenderer extends Renderer {
         this.emit(' ');
         this.renderBlock(x.body);
         this.emit(';');
+      }),
+      typeCase(TypeDeclarationStatement, (x) => {
+        this.renderDeclaration(x.decl);
       }),
     ]);
 

--- a/packages/@cdklabs/typewriter/src/scope.ts
+++ b/packages/@cdklabs/typewriter/src/scope.ts
@@ -170,3 +170,18 @@ export class RichScope {
     return this.scope.tryFindType(this.scope.qualifyName(name));
   }
 }
+
+/**
+ * A scope that is never meant to be added to the syntax tree. Useful for
+ * when you have to add something to a scope, but don't want it to be
+ * rendered automatically by the renderer when traversing the tree.
+ *
+ * Example: if you want to render an inner class, inside a method, wrap
+ * the class in a TypeDeclarationStatement. If you add the class to the
+ * dummy scope, it will only be rendered as part of the statement.
+ */
+export class DummyScope extends ScopeImpl {
+  constructor() {
+    super('<dummy scope>');
+  }
+}

--- a/packages/@cdklabs/typewriter/src/statements/statements.ts
+++ b/packages/@cdklabs/typewriter/src/statements/statements.ts
@@ -3,6 +3,7 @@ import { asStmt } from './private';
 import { CommentableImpl, ICommentable } from '../code-fragments';
 import { Expression } from '../expressions';
 import { Parameter } from '../parameter';
+import { TypeDeclaration } from '../type-declaration';
 
 export class Statement extends CommentableImpl implements ICommentable {}
 
@@ -105,6 +106,12 @@ export class MonkeyPatchMethod extends Statement {
     public readonly parameters: Parameter[],
     public readonly body: Block,
   ) {
+    super();
+  }
+}
+
+export class TypeDeclarationStatement extends Statement {
+  constructor(public readonly decl: TypeDeclaration) {
     super();
   }
 }

--- a/packages/@cdklabs/typewriter/test/scope.test.ts
+++ b/packages/@cdklabs/typewriter/test/scope.test.ts
@@ -1,0 +1,62 @@
+import { ClassType, DummyScope, FreeFunction, Module, TypeDeclarationStatement, TypeScriptRenderer } from '../src';
+
+const renderer = new TypeScriptRenderer();
+let scope: Module;
+
+beforeEach(() => {
+  scope = new Module('typewriter.test');
+});
+
+test('renders a class inside a free function', () => {
+  const fn = new FreeFunction(scope, {
+    name: 'freeFunction',
+  });
+
+  fn.addBody(
+    new TypeDeclarationStatement(
+      new ClassType(new DummyScope(), {
+        name: 'MyClass',
+      }),
+    ),
+  );
+
+  expect(renderer.render(scope)).toMatchInlineSnapshot(`
+    "/* eslint-disable prettier/prettier, @stylistic/max-len */
+    // @ts-ignore TS6133
+    function freeFunction(): void {
+      class MyClass {
+
+      }
+    }"
+  `);
+});
+
+test('renders a class inside a class method', () => {
+  const outerClass = new ClassType(scope, {
+    name: 'OuterClass',
+    export: true,
+  });
+
+  const method = outerClass.addMethod({
+    name: 'doSomething',
+  });
+
+  method.addBody(
+    new TypeDeclarationStatement(
+      new ClassType(new DummyScope(), {
+        name: 'MyClass',
+      }),
+    ),
+  );
+
+  expect(renderer.render(scope)).toMatchInlineSnapshot(`
+    "/* eslint-disable prettier/prettier, @stylistic/max-len */
+    export class OuterClass {
+      public doSomething(): void {
+        class MyClass {
+
+        }
+      }
+    }"
+  `);
+});


### PR DESCRIPTION
Motivation: to generate a class inside a method. Code like this:

```ts
method.addBody(
  new TypeDeclarationStatement(
    new ClassType(new DummyScope(), {
      name: 'MyClass',
    }),
  ),
);
```

can be used to generate code like this:

```ts
export class OuterClass {
  public doSomething(): void {
    class MyClass {
    }
  }
}
```