### PR TITLE
feat: add relationshipRefs on resource properties

### DIFF
--- a/packages/@aws-cdk/service-spec-importers/schemas/CloudFormationRegistryResource.schema.json
+++ b/packages/@aws-cdk/service-spec-importers/schemas/CloudFormationRegistryResource.schema.json
@@ -658,22 +658,6 @@
       ],
       "type": "object"
     },
-    "jsonschema.RelationshipRefSchema": {
-      "additionalProperties": false,
-      "properties": {
-        "propertyPath": {
-          "type": "string"
-        },
-        "typeName": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "typeName",
-        "propertyPath"
-      ],
-      "type": "object"
-    },
     "jsonschema.Schema": {
       "anyOf": [
         {
@@ -687,9 +671,6 @@
         },
         {
           "$ref": "#/definitions/jsonschema.AllOf%3CSchema%3E"
-        },
-        {
-          "$ref": "#/definitions/jsonschema.RelationshipRefSchema"
         }
       ]
     },
@@ -800,9 +781,6 @@
         },
         "pattern": {
           "type": "string"
-        },
-        "relationshipRef": {
-          "$ref": "#/definitions/jsonschema.RelationshipRefSchema"
         },
         "title": {
           "type": "string"

--- a/packages/@aws-cdk/service-spec-importers/schemas/SamTemplateSchema.schema.json
+++ b/packages/@aws-cdk/service-spec-importers/schemas/SamTemplateSchema.schema.json
@@ -416,22 +416,6 @@
       ],
       "type": "object"
     },
-    "jsonschema.RelationshipRefSchema": {
-      "additionalProperties": false,
-      "properties": {
-        "propertyPath": {
-          "type": "string"
-        },
-        "typeName": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "typeName",
-        "propertyPath"
-      ],
-      "type": "object"
-    },
     "jsonschema.Schema": {
       "anyOf": [
         {
@@ -445,9 +429,6 @@
         },
         {
           "$ref": "#/definitions/jsonschema.AllOf%3CSchema%3E"
-        },
-        {
-          "$ref": "#/definitions/jsonschema.RelationshipRefSchema"
         }
       ]
     },
@@ -638,9 +619,6 @@
         },
         "pattern": {
           "type": "string"
-        },
-        "relationshipRef": {
-          "$ref": "#/definitions/jsonschema.RelationshipRefSchema"
         },
         "title": {
           "type": "string"

--- a/packages/@aws-cdk/service-spec-types/src/types/resource.ts
+++ b/packages/@aws-cdk/service-spec-types/src/types/resource.ts
@@ -487,7 +487,7 @@ export interface RelationshipRef {
   /**
    * The CloudFormation resource type this property references
    */
-  readonly typeName: string;
+  readonly cloudFormationType: string;
 
   /**
    * The property name within the referenced resource (e.g., "Id")


### PR DESCRIPTION
### Changes
Add support for the `relationshipRefs` property for resource properties. This new type will hold the relationship information between the current property and multiple pairs of `{ typeName, propertyName }`.

For example if the `AWS::Lambda::Function Role` property has relationshipRefs `[{ typeName: "AWS::IAM::Role", propertyName: "Arn" }]` it means that the role property of the lambda function would accept the arn property of the IAM role