### PR TITLE
feat: import relationships from Cloudformation schema

### DIFF
--- a/packages/@aws-cdk/service-spec-importers/schemas/CloudFormationRegistryResource.schema.json
+++ b/packages/@aws-cdk/service-spec-importers/schemas/CloudFormationRegistryResource.schema.json
@@ -658,6 +658,22 @@
       ],
       "type": "object"
     },
+    "jsonschema.RelationshipRefSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "propertyPath": {
+          "type": "string"
+        },
+        "typeName": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "typeName",
+        "propertyPath"
+      ],
+      "type": "object"
+    },
     "jsonschema.Schema": {
       "anyOf": [
         {
@@ -671,6 +687,9 @@
         },
         {
           "$ref": "#/definitions/jsonschema.AllOf%3CSchema%3E"
+        },
+        {
+          "$ref": "#/definitions/jsonschema.RelationshipRefSchema"
         }
       ]
     },
@@ -781,6 +800,9 @@
         },
         "pattern": {
           "type": "string"
+        },
+        "relationshipRef": {
+          "$ref": "#/definitions/jsonschema.RelationshipRefSchema"
         },
         "title": {
           "type": "string"

--- a/packages/@aws-cdk/service-spec-importers/schemas/SamTemplateSchema.schema.json
+++ b/packages/@aws-cdk/service-spec-importers/schemas/SamTemplateSchema.schema.json
@@ -416,6 +416,22 @@
       ],
       "type": "object"
     },
+    "jsonschema.RelationshipRefSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "propertyPath": {
+          "type": "string"
+        },
+        "typeName": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "typeName",
+        "propertyPath"
+      ],
+      "type": "object"
+    },
     "jsonschema.Schema": {
       "anyOf": [
         {
@@ -429,6 +445,9 @@
         },
         {
           "$ref": "#/definitions/jsonschema.AllOf%3CSchema%3E"
+        },
+        {
+          "$ref": "#/definitions/jsonschema.RelationshipRefSchema"
         }
       ]
     },
@@ -619,6 +638,9 @@
         },
         "pattern": {
           "type": "string"
+        },
+        "relationshipRef": {
+          "$ref": "#/definitions/jsonschema.RelationshipRefSchema"
         },
         "title": {
           "type": "string"

--- a/packages/@aws-cdk/service-spec-importers/src/db-diff.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/db-diff.ts
@@ -144,6 +144,7 @@ export class DbDiff {
       previousTypes: collapseEmptyDiff(diffList(a.previousTypes ?? [], b.previousTypes ?? [], eqType)),
       type: diffField(a, b, 'type', eqType),
       causesReplacement: diffScalar(a, b, 'causesReplacement'),
+      relationshipRefs: diffField(a, b, 'relationshipRefs', jsonEq),
     } satisfies DontCareAboutTypes<AllFieldsGiven<Property>>);
 
     if (anyDiffs) {

--- a/packages/@aws-cdk/service-spec-importers/src/importers/import-cloudformation-registry.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/importers/import-cloudformation-registry.ts
@@ -1,4 +1,4 @@
-import { PropertyType, RichPropertyType, SpecDatabase, TagVariant } from '@aws-cdk/service-spec-types';
+import { PropertyType, RelationshipRef, RichPropertyType, SpecDatabase, TagVariant } from '@aws-cdk/service-spec-types';
 import { locateFailure, Fail, failure, isFailure, Result, tryCatch, using, ref, isSuccess } from '@cdklabs/tskb';
 import { ProblemReport, ReportAudience } from '../report';
 import { PropertyBagBuilder, SpecBuilder } from '../resource-builder';
@@ -76,6 +76,7 @@ export function importCloudFormationRegistryResource(options: LoadCloudFormation
             documentation: descriptionOf(resolvedSchema),
             required: required.has(name),
             defaultValue: describeDefault(resolvedSchema),
+            relationshipRefs: extractRelationshipRefs(resolvedSchema),
           });
         });
       } catch (e) {
@@ -85,6 +86,39 @@ export function importCloudFormationRegistryResource(options: LoadCloudFormation
         );
       }
     }
+  }
+
+  /**
+   * Recursively extracts relationshipRef metadata from JSON schemas
+   *
+   * Finds relationshipRef objects that indicate this property references
+   * another CloudFormation resource, and converts property paths to name.
+   */
+  function extractRelationshipRefs(schema: jsonschema.ResolvedSchema): RelationshipRef[] {
+    const refs: RelationshipRef[] = [];
+
+    function collectRefs(s: jsonschema.ConcreteSchema) {
+      if (jsonschema.isAnyType(s)) return;
+
+      if ('relationshipRef' in s && s.relationshipRef) {
+        refs.push({
+          typeName: s.relationshipRef.typeName,
+          propertyName: s.relationshipRef.propertyPath.startsWith('/properties/')
+            ? s.relationshipRef.propertyPath.slice(12)
+            : s.relationshipRef.propertyPath,
+        });
+      }
+
+      // We cannot use jsonschema.anyOf / oneOf because a relationshipRef has not type in the schema
+      if (jsonschema.isAnyOf(s) || jsonschema.isOneOf(s)) {
+        jsonschema.innerSchemas(s).forEach(collectRefs);
+      } else if (jsonschema.isArray(s) && s.items) {
+        collectRefs(resolve(s.items));
+      }
+    }
+
+    collectRefs(schema);
+    return refs;
   }
 
   /**
@@ -155,6 +189,9 @@ export function importCloudFormationRegistryResource(options: LoadCloudFormation
         // FIXME: Do a proper thing here
         const firstResolved = resolvedSchema.allOf[0];
         return schemaTypeToModelType(nameHint, resolve(firstResolved), fail);
+      } else if (jsonschema.isRelationshipRef(resolvedSchema)) {
+        // relationshipRef schema - treat as string
+        return { type: 'string' };
       } else {
         switch (resolvedSchema.type) {
           case 'string':
@@ -196,9 +233,13 @@ export function importCloudFormationRegistryResource(options: LoadCloudFormation
 
   function validateCombiningSchemaType(schema: jsonschema.ConcreteSchema[], fail: Fail) {
     schema.forEach((element, index) => {
-      if (!jsonschema.isAnyType(element) && !jsonschema.isCombining(element)) {
+      if (
+        !jsonschema.isAnyType(element) &&
+        !jsonschema.isCombining(element) &&
+        !jsonschema.isRelationshipRef(element)
+      ) {
         schema.slice(index + 1).forEach((next) => {
-          if (!jsonschema.isAnyType(next) && !jsonschema.isCombining(next)) {
+          if (!jsonschema.isAnyType(next) && !jsonschema.isCombining(next) && !jsonschema.isRelationshipRef(next)) {
             if (element.title === next.title && element.type !== next.type) {
               report.reportFailure(
                 'interpreting',
@@ -323,7 +364,8 @@ export function importCloudFormationRegistryResource(options: LoadCloudFormation
       jsonschema.isAnyType(schema) ||
       jsonschema.isAllOf(schema) ||
       jsonschema.isAnyOf(schema) ||
-      jsonschema.isOneOf(schema)
+      jsonschema.isOneOf(schema) ||
+      jsonschema.isRelationshipRef(schema)
     ) {
       return undefined;
     }
@@ -401,7 +443,7 @@ export function importCloudFormationRegistryResource(options: LoadCloudFormation
 }
 
 function descriptionOf(x: jsonschema.ConcreteSchema) {
-  return jsonschema.isAnyType(x) ? undefined : x.description;
+  return jsonschema.isAnyType(x) || jsonschema.isRelationshipRef(x) ? undefined : x.description;
 }
 
 function lastWord(x: string): string {

--- a/packages/@aws-cdk/service-spec-importers/src/patching/field-witnesses.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/patching/field-witnesses.ts
@@ -21,6 +21,7 @@ export const STRING_KEY_WITNESS: TypeKeyWitness<jsonschema.String> = {
   pattern: true,
   title: true,
   const: true,
+  relationshipRef: true,
 };
 
 export const NUMBER_KEY_WITNESS: TypeKeyWitness<jsonschema.Number> = {

--- a/packages/@aws-cdk/service-spec-importers/src/resource-builder.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/resource-builder.ts
@@ -159,6 +159,7 @@ export class PropertyBagBuilder {
       documentation: updates.documentation,
       required: updates.required,
       scrutinizable: updates.scrutinizable,
+      relationshipRefs: updates.relationshipRefs,
 
       // These will be handled specially below
       previousTypes: undefined,

--- a/packages/@aws-cdk/service-spec-importers/src/types/registry-schema/JsonSchema.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/types/registry-schema/JsonSchema.ts
@@ -1,7 +1,7 @@
 import { CommonTypeCombinatorFields } from './CloudFormationRegistrySchema';
 
 export namespace jsonschema {
-  export type Schema = SingletonSchema | OneOf<Schema> | AnyOf<Schema> | AllOf<Schema>;
+  export type Schema = SingletonSchema | OneOf<Schema> | AnyOf<Schema> | AllOf<Schema> | RelationshipRefSchema;
 
   export type SingletonSchema = Reference | ConcreteSingletonSchema;
 
@@ -9,7 +9,8 @@ export namespace jsonschema {
     | ConcreteSingletonSchema
     | OneOf<ConcreteSchema>
     | AnyOf<ConcreteSchema>
-    | AllOf<ConcreteSchema>;
+    | AllOf<ConcreteSchema>
+    | RelationshipRefSchema;
 
   export type ConcreteSingletonSchema = Object | String | SchemaArray | Boolean | Number | Null | AnyType;
 
@@ -91,7 +92,11 @@ export namespace jsonschema {
   export function isAnyOf(x: Schema | CommonTypeCombinatorFields): x is AnyOf<any> {
     if (x && !isAnyType(x) && 'anyOf' in x) {
       for (const elem of x.anyOf!) {
-        if (elem && !isAnyType(elem) && (isTypeDefined(elem) || isReference(elem) || isAnyOf(elem) || isOneOf(elem))) {
+        if (
+          elem &&
+          !isAnyType(elem) &&
+          (isTypeDefined(elem) || isReference(elem) || isAnyOf(elem) || isOneOf(elem) || isRelationshipRef(elem))
+        ) {
           return true;
         }
       }
@@ -119,7 +124,10 @@ export namespace jsonschema {
   export function isOneOf(x: Schema | CommonTypeCombinatorFields): x is OneOf<any> {
     if (x && !isAnyType(x) && 'oneOf' in x) {
       for (const elem of x.oneOf!) {
-        if (!isAnyType(elem) && (isTypeDefined(elem) || isReference(elem) || isAnyOf(elem) || isOneOf(elem))) {
+        if (
+          !isAnyType(elem) &&
+          (isTypeDefined(elem) || isReference(elem) || isAnyOf(elem) || isOneOf(elem) || isRelationshipRef(elem))
+        ) {
           return true;
         }
       }
@@ -199,6 +207,18 @@ export namespace jsonschema {
     return !(x as RecordLikeObject).properties;
   }
 
+  export interface RelationshipRefSchema {
+    readonly typeName: string;
+    readonly propertyPath: string;
+  }
+
+  /**
+   * Determines if a schema is a relationshipRef (only has relationshipRef, no type)
+   */
+  export function isRelationshipRef(x: any): x is RelationshipRefSchema {
+    return x && typeof x === 'object' && 'relationshipRef' in x && !('type' in x);
+  }
+
   export interface String extends Annotatable {
     readonly type: 'string';
     readonly default?: string;
@@ -209,6 +229,7 @@ export namespace jsonschema {
     readonly enum?: string[];
     readonly format?: 'date-time' | 'uri' | 'timestamp';
     readonly examples?: string[];
+    readonly relationshipRef?: RelationshipRefSchema;
   }
 
   export function isString(x: ConcreteSchema): x is String {

--- a/packages/@aws-cdk/service-spec-importers/test/cloudformation-registry.test.ts
+++ b/packages/@aws-cdk/service-spec-importers/test/cloudformation-registry.test.ts
@@ -1,6 +1,7 @@
 import { emptyDatabase } from '@aws-cdk/service-spec-types';
 import { importCloudFormationRegistryResource } from '../src/importers/import-cloudformation-registry';
 import { ProblemReport } from '../src/report';
+import { CloudFormationRegistryResource } from '../src/types';
 
 let db: ReturnType<typeof emptyDatabase>;
 let report: ProblemReport;
@@ -34,6 +35,74 @@ test('include primaryIdentifier in database', () => {
   // eslint-disable-next-line prettier/prettier
   const primaryIdentifier = db.lookup('resource', 'cloudFormationType', 'equals', 'AWS::Some::Type')[0]?.primaryIdentifier;
   expect(primaryIdentifier).toEqual(['id', 'secondId']);
+});
+
+test('relationshipRef extraction', () => {
+  importCloudFormationRegistryResource({
+    db,
+    report,
+    resource: {
+      typeName: 'AWS::EC2::VPCEndpoint',
+      description:
+        'Specifies a VPC endpoint. A VPC endpoint provides a private connection between your VPC and an endpoint service.',
+      properties: {
+        SecurityGroupIds: {
+          uniqueItems: true,
+          description:
+            'The IDs of the security groups to associate with the endpoint network interfaces. If this parameter is not specified, we use the default security group for the VPC. Security groups are supported only for interface endpoints.',
+          insertionOrder: false,
+          type: 'array',
+          items: {
+            anyOf: [
+              {
+                relationshipRef: {
+                  typeName: 'AWS::EC2::SecurityGroup',
+                  propertyPath: '/properties/GroupId',
+                },
+              },
+              {
+                relationshipRef: {
+                  typeName: 'AWS::EC2::SecurityGroup',
+                  propertyPath: '/properties/Id',
+                },
+              },
+              {
+                relationshipRef: {
+                  typeName: 'AWS::EC2::VPC',
+                  propertyPath: '/properties/DefaultSecurityGroup',
+                },
+              },
+            ],
+            type: 'string',
+          },
+        },
+        SubnetIds: {
+          type: 'array',
+          items: {
+            relationshipRef: {
+              typeName: 'AWS::EC2::Subnet',
+              propertyPath: '/properties/SubnetId',
+            },
+            type: 'string',
+          },
+        },
+      },
+    } as CloudFormationRegistryResource,
+  });
+
+  const resource = db.lookup('resource', 'cloudFormationType', 'equals', 'AWS::EC2::VPCEndpoint')[0];
+
+  // Check array with anyOf relationships
+  expect(resource.properties.SecurityGroupIds.relationshipRefs).toEqual([
+    { typeName: 'AWS::EC2::SecurityGroup', propertyName: 'GroupId' },
+    { typeName: 'AWS::EC2::SecurityGroup', propertyName: 'Id' },
+    { typeName: 'AWS::EC2::VPC', propertyName: 'DefaultSecurityGroup' },
+  ]);
+
+  // Check simple array relationship
+  expect(resource.properties.SubnetIds.relationshipRefs).toEqual([
+    { typeName: 'AWS::EC2::Subnet', propertyName: 'SubnetId' },
+  ]);
 });
 
 test('deprecated properties', () => {

--- a/packages/@aws-cdk/service-spec-types/src/types/resource.ts
+++ b/packages/@aws-cdk/service-spec-types/src/types/resource.ts
@@ -490,9 +490,9 @@ export interface RelationshipRef {
   readonly typeName: string;
 
   /**
-   * The property path within the referenced resource (e.g., "/Id")
+   * The property name within the referenced resource (e.g., "Id")
    */
-  readonly propertyPath: string;
+  readonly propertyName: string;
 }
 
 export class RichPropertyType {

--- a/packages/@aws-cdk/service-spec-types/src/types/resource.ts
+++ b/packages/@aws-cdk/service-spec-types/src/types/resource.ts
@@ -165,6 +165,11 @@ export interface Property {
    * @default 'no'
    */
   causesReplacement?: 'yes' | 'no' | 'maybe';
+
+  /**
+   * Relationship references to other CloudFormation resources
+   */
+  relationshipRefs?: RelationshipRef[];
 }
 
 export class RichTypedField {
@@ -473,6 +478,21 @@ export enum PropertyScrutinyType {
    * A set of egress rules (on a security group)
    */
   EgressRules = 'EgressRules',
+}
+
+/**
+ * Represents a relationship reference to another CloudFormation resource
+ */
+export interface RelationshipRef {
+  /**
+   * The CloudFormation resource type this property references
+   */
+  readonly typeName: string;
+
+  /**
+   * The property path within the referenced resource (e.g., "/Id")
+   */
+  readonly propertyPath: string;
 }
 
 export class RichPropertyType {


### PR DESCRIPTION
Related to #2067

This PR imports the relationship information from the Cloudformation schema, to populate the properties `relationshipRef` of the database.

The relationship information in the schema for a single relationship looks like:
```
    "SubnetIds" : {
      "uniqueItems" : true,
      "description" : "The IDs of the subnets ...",
      "insertionOrder" : false,
      "type" : "array",
      "items" : {
        "relationshipRef" : {
          "typeName" : "AWS::EC2::Subnet",
          "propertyPath" : "/properties/SubnetId"
        },
        "type" : "string"
      }
    },
```
And a property with multiple relationship looks like this:
```
    "SecurityGroupIds" : {
      "uniqueItems" : true,
      "description" : "The IDs of the security groups ...",
      "insertionOrder" : false,
      "type" : "array",
      "items" : {
        "anyOf" : [ {
          "relationshipRef" : {
            "typeName" : "AWS::EC2::SecurityGroup",
            "propertyPath" : "/properties/GroupId"
          }
        }, {
          "relationshipRef" : {
            "typeName" : "AWS::EC2::SecurityGroup",
            "propertyPath" : "/properties/Id"
          }
        }, {
          "relationshipRef" : {
            "typeName" : "AWS::EC2::VPC",
            "propertyPath" : "/properties/DefaultSecurityGroup"
          }
        } ],
        "type" : "string"
      }
    },
```

### Testing
Added a unit test for one and multiple relationships, verified the produced data in the database.