### PR TITLE
feat(canned-metrics): add `previousStatistics` field to canned metrics

### DIFF
--- a/packages/@aws-cdk/service-spec-importers/src/db-diff.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/db-diff.ts
@@ -104,6 +104,7 @@ export class DbDiff {
   private diffMetric(a: Metric, b: Metric): ChangedMetric | undefined {
     return collapseUndefined({
       statistic: diffScalar(a, b, 'statistic'),
+      previousStatistics: diffField(a, b, 'previousStatistics', jsonEq),
       description: diffScalar(a, b, 'description'),
       dimensionSets: this.diffMetricDimensionSets(a, b),
     } satisfies AllFieldsGiven<ChangedMetric>);

--- a/packages/@aws-cdk/service-spec-importers/src/db-diff.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/db-diff.ts
@@ -104,7 +104,7 @@ export class DbDiff {
   private diffMetric(a: Metric, b: Metric): ChangedMetric | undefined {
     return collapseUndefined({
       statistic: diffScalar(a, b, 'statistic'),
-      previousStatistics: diffField(a, b, 'previousStatistics', jsonEq),
+      previousStatistics: diffField(a, b, 'previousStatistics', jsonEq, []),
       description: diffScalar(a, b, 'description'),
       dimensionSets: this.diffMetricDimensionSets(a, b),
     } satisfies AllFieldsGiven<ChangedMetric>);

--- a/packages/@aws-cdk/service-spec-importers/src/diff-fmt.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/diff-fmt.ts
@@ -239,7 +239,7 @@ export class DiffFormatter {
   }
 
   private renderUpdatedMetric(k: string, u: ChangedMetric): PrintableTree {
-    const d = pick(u, ['statistic', 'description']);
+    const d = pick(u, ['statistic', 'previousStatistics', 'description']);
     return new PrintableTree(k).addBullets([
       new PrintableTree(...listFromDiffs(d)).indent(META_INDENT),
       listWithCaption(

--- a/packages/@aws-cdk/service-spec-importers/src/importers/import-canned-metrics.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/importers/import-canned-metrics.ts
@@ -68,6 +68,7 @@ export function importCannedMetrics(
               name: metricDef.name,
               namespace: group.namespace,
               statistic: metricDef.defaultStat,
+              previousStatistics: [],
             }),
           );
           db.link('usesDimensionSet', metric, dimensionSet);

--- a/packages/@aws-cdk/service-spec-importers/test/db-diff.test.ts
+++ b/packages/@aws-cdk/service-spec-importers/test/db-diff.test.ts
@@ -54,6 +54,30 @@ test('metrics diff only on statistic and ignore dedup key for diff', () => {
   });
 });
 
+test('metrics diff detects previousStatistics change', () => {
+  const m1 = db1.allocate('metric', {
+    namespace: 'NS',
+    name: 'Name',
+    statistic: 'Average',
+    previousStatistics: ['Average'],
+    dedupKey: '1',
+  });
+  const m2 = db2.allocate('metric', {
+    namespace: 'NS',
+    name: 'Name',
+    statistic: 'Average',
+    previousStatistics: ['Average', 'Sum'],
+    dedupKey: '2',
+  });
+
+  const md = diff.diffMetrics([m1], [m2]);
+  const changes = Object.values(md?.updated || {});
+  expect(changes.length).toBe(1);
+  expect(changes[0]).toMatchObject({
+    previousStatistics: { old: ['Average'], new: ['Average', 'Sum'] },
+  });
+});
+
 test('metrics diff detects description change', () => {
   const m1 = db1.allocate('metric', {
     namespace: 'NS',

--- a/packages/@aws-cdk/service-spec-importers/test/db-diff.test.ts
+++ b/packages/@aws-cdk/service-spec-importers/test/db-diff.test.ts
@@ -31,8 +31,20 @@ test('property diff ignores union order, even when using type references', () =>
 });
 
 test('metrics diff only on statistic and ignore dedup key for diff', () => {
-  const m1 = db1.allocate('metric', { namespace: 'NS', name: 'Name', statistic: 'Average', dedupKey: '1' });
-  const m2 = db2.allocate('metric', { namespace: 'NS', name: 'Name', statistic: 'Maximum', dedupKey: '2' });
+  const m1 = db1.allocate('metric', {
+    namespace: 'NS',
+    name: 'Name',
+    statistic: 'Average',
+    previousStatistics: [],
+    dedupKey: '1',
+  });
+  const m2 = db2.allocate('metric', {
+    namespace: 'NS',
+    name: 'Name',
+    statistic: 'Maximum',
+    previousStatistics: [],
+    dedupKey: '2',
+  });
 
   const md = diff.diffMetrics([m1], [m2]);
   const changes = Object.values(md?.updated || {});
@@ -47,6 +59,7 @@ test('metrics diff detects description change', () => {
     namespace: 'NS',
     name: 'Name',
     statistic: 'Average',
+    previousStatistics: ['Average'],
     dedupKey: '1',
     description: 'old desc',
   });
@@ -54,6 +67,7 @@ test('metrics diff detects description change', () => {
     namespace: 'NS',
     name: 'Name',
     statistic: 'Average',
+    previousStatistics: ['Average'],
     dedupKey: '2',
     description: 'new desc',
   });
@@ -67,8 +81,20 @@ test('metrics diff detects description change', () => {
 });
 
 test('metrics diff detects dimension set added', () => {
-  const m1 = db1.allocate('metric', { namespace: 'NS', name: 'Name', statistic: 'Average', dedupKey: '1' });
-  const m2 = db2.allocate('metric', { namespace: 'NS', name: 'Name', statistic: 'Average', dedupKey: '2' });
+  const m1 = db1.allocate('metric', {
+    namespace: 'NS',
+    name: 'Name',
+    statistic: 'Average',
+    previousStatistics: ['Average'],
+    dedupKey: '1',
+  });
+  const m2 = db2.allocate('metric', {
+    namespace: 'NS',
+    name: 'Name',
+    statistic: 'Average',
+    previousStatistics: ['Average'],
+    dedupKey: '2',
+  });
 
   const ds = db2.allocate('dimensionSet', {
     dedupKey: 'ds1',
@@ -86,8 +112,20 @@ test('metrics diff detects dimension set added', () => {
 });
 
 test('metrics diff detects dimension set removed', () => {
-  const m1 = db1.allocate('metric', { namespace: 'NS', name: 'Name', statistic: 'Average', dedupKey: '1' });
-  const m2 = db2.allocate('metric', { namespace: 'NS', name: 'Name', statistic: 'Average', dedupKey: '2' });
+  const m1 = db1.allocate('metric', {
+    namespace: 'NS',
+    name: 'Name',
+    statistic: 'Average',
+    previousStatistics: ['Average'],
+    dedupKey: '1',
+  });
+  const m2 = db2.allocate('metric', {
+    namespace: 'NS',
+    name: 'Name',
+    statistic: 'Average',
+    previousStatistics: ['Average'],
+    dedupKey: '2',
+  });
 
   const ds = db1.allocate('dimensionSet', {
     dedupKey: 'ds1',
@@ -105,8 +143,20 @@ test('metrics diff detects dimension set removed', () => {
 });
 
 test('metrics diff detects dimension set dimensions changed', () => {
-  const m1 = db1.allocate('metric', { namespace: 'NS', name: 'Name', statistic: 'Average', dedupKey: '1' });
-  const m2 = db2.allocate('metric', { namespace: 'NS', name: 'Name', statistic: 'Average', dedupKey: '2' });
+  const m1 = db1.allocate('metric', {
+    namespace: 'NS',
+    name: 'Name',
+    statistic: 'Average',
+    previousStatistics: ['Average'],
+    dedupKey: '1',
+  });
+  const m2 = db2.allocate('metric', {
+    namespace: 'NS',
+    name: 'Name',
+    statistic: 'Average',
+    previousStatistics: ['Average'],
+    dedupKey: '2',
+  });
 
   const ds1 = db1.allocate('dimensionSet', {
     dedupKey: 'ds1',
@@ -135,8 +185,20 @@ test('metrics diff detects dimension set dimensions changed', () => {
 });
 
 test('metrics diff reports no change when dimension sets are identical', () => {
-  const m1 = db1.allocate('metric', { namespace: 'NS', name: 'Name', statistic: 'Average', dedupKey: '1' });
-  const m2 = db2.allocate('metric', { namespace: 'NS', name: 'Name', statistic: 'Average', dedupKey: '2' });
+  const m1 = db1.allocate('metric', {
+    namespace: 'NS',
+    name: 'Name',
+    statistic: 'Average',
+    previousStatistics: ['Average'],
+    dedupKey: '1',
+  });
+  const m2 = db2.allocate('metric', {
+    namespace: 'NS',
+    name: 'Name',
+    statistic: 'Average',
+    previousStatistics: ['Average'],
+    dedupKey: '2',
+  });
 
   const ds1 = db1.allocate('dimensionSet', {
     dedupKey: 'ds1',

--- a/packages/@aws-cdk/service-spec-types/src/types/diff.ts
+++ b/packages/@aws-cdk/service-spec-types/src/types/diff.ts
@@ -30,6 +30,7 @@ export interface UpdatedService {
 
 export interface ChangedMetric {
   readonly statistic?: ScalarDiff<string>;
+  readonly previousStatistics?: ScalarDiff<string[]>;
   readonly description?: ScalarDiff<string>;
   readonly dimensionSets?: MapDiff<DimensionSet, ChangedDimensionSet>;
 }

--- a/packages/@aws-cdk/service-spec-types/src/types/metrics.ts
+++ b/packages/@aws-cdk/service-spec-types/src/types/metrics.ts
@@ -52,6 +52,10 @@ export interface Metric extends Entity {
    */
   readonly statistic: string;
   /**
+   * An ordered list of the of the default statistics for this metric
+   */
+  readonly previousStatistics: string[];
+  /**
    * A unique value used to deduplicate the entity
    */
   readonly dedupKey: string;


### PR DESCRIPTION
 This change adds a previousStatistics field to the Metric entity to track the history of default statistics as they change across data source imports. This is analogous to how `previousTypes` works for property types — the current statistic remains the primary value, while `previousStatistics` accumulates any differing statistics seen in subsequent imports. **Currently the value is set to an empty array as the datasource does not contain it yet**

 Changes:
  - `@aws-cdk/service-spec-types`: Added previousStatistics: string[] to the Metric interface and ScalarDiff<string[]> to ChangedMetric for diff support.
  - `@aws-cdk/service-spec-importers`:
    - Updated the canned metrics importer to initialize previousStatistics as [] on new metrics.
    - Updated DbDiff to diff previousStatistics
    - Updated DiffFormatter to render previousStatistics changes.

 - Tests: Updated all metric allocations in db-diff.test.ts to include the new required field and added a new unit test
