### PR TITLE
feat(canned-metrics): add dimension-sets names

### DIFF
--- a/packages/@aws-cdk/aws-service-spec/build/full-database.ts
+++ b/packages/@aws-cdk/aws-service-spec/build/full-database.ts
@@ -24,9 +24,7 @@ export class FullDatabase extends DatabaseBuilder {
       .importGetAttAllowList(path.join(SOURCES, 'CloudFormationGetAttAllowList/gettatt-allowlist.json'))
       .importArnTemplates(path.join(SOURCES, 'ArnTemplates/arn-templates.json'), path.join(SOURCES, 'ArnTemplates/arn-overrides.json'))
       .importOobRelationships(path.join(SOURCES, 'OobRelationships/relationships.json'), patchOobRelationships)
-      .importCannedMetrics(
-        path.join(SOURCES, 'CloudWatchConsoleServiceDirectory/CloudWatchConsoleServiceDirectory.json'),
-      )
+      .importCannedMetrics(path.join(SOURCES, 'CloudWatchConsoleServiceDirectory'))
       .importLogSources(path.join(SOURCES, 'LogSources/log-source-resource.json'))
       .importScrutinies()
       .importAugmentations()

--- a/packages/@aws-cdk/service-spec-importers/src/db-builder.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/db-builder.ts
@@ -29,6 +29,7 @@ import {
 import { loadDefaultEventBridgeSchema } from './loaders/load-eventbridge-schema';
 import { JsonLensPatcher } from './patching';
 import { ProblemReport, ReportAudience } from './report';
+import { DimensionSetNames } from './types';
 
 export interface DatabaseBuilderOptions {
   /**
@@ -179,13 +180,19 @@ export class DatabaseBuilder {
   /**
    * Import canned metrics from the CloudWatch Console Service Directory
    */
-  public importCannedMetrics(filePath: string) {
+  public importCannedMetrics(directoryPath: string) {
     return this.addSourceImporter(async (db, report) => {
       const cloudWatchServiceDirectory = this.loadResult(
-        await loadDefaultCloudWatchConsoleServiceDirectory(filePath, this.options),
+        await loadDefaultCloudWatchConsoleServiceDirectory(
+          `${directoryPath}/CloudWatchConsoleServiceDirectory.json`,
+          this.options,
+        ),
         report,
       );
-      importCannedMetrics(db, cloudWatchServiceDirectory, report);
+      const dimensionSetNames: DimensionSetNames = JSON.parse(
+        await fs.readFile(`${directoryPath}/dimension-sets-names.json`, 'utf-8'),
+      );
+      importCannedMetrics(db, cloudWatchServiceDirectory, report, dimensionSetNames);
     });
   }
 

--- a/packages/@aws-cdk/service-spec-importers/src/importers/import-canned-metrics.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/importers/import-canned-metrics.ts
@@ -2,7 +2,7 @@ import { createHash } from 'crypto';
 import { SpecDatabase } from '@aws-cdk/service-spec-types';
 import { Entity, failure, Plain } from '@cdklabs/tskb';
 import { ProblemReport, ReportAudience } from '../report';
-import { CloudWatchConsoleServiceDirectory } from '../types';
+import { CloudWatchConsoleServiceDirectory, DimensionSetNames } from '../types';
 
 /**
  * Returns a deduplicatable entity
@@ -34,23 +34,32 @@ export function importCannedMetrics(
   db: SpecDatabase,
   serviceDirectoryEntries: CloudWatchConsoleServiceDirectory,
   report: ProblemReport,
+  dimensionSetNames: DimensionSetNames,
 ) {
   const skippedResources = new Set<string>();
 
   for (const { metricTemplates: groups = [] } of serviceDirectoryEntries) {
     for (const group of groups) {
+      // Resolve dimension set name
+      const dimensions = group.dimensions.map((d) => ({
+        name: d.dimensionName,
+        value: d.dimensionValue,
+      }));
+      const dimKey = dimensions
+        .map((d) => d.name)
+        .sort()
+        .join(',');
+      const dimsetName = dimKey === '' ? 'Account' : dimensionSetNames[group.namespace]?.[dimKey];
+      if (!dimsetName) {
+        throw new Error(`No dimension set name found for namespace '${group.namespace}', dimensions '${dimKey}'`);
+      }
+
       try {
         const resourceType = group.resourceType.split('/', 1).at(0)!; // some resource types in this dataset have a custom suffix
         const resource = db.lookup('resource', 'cloudFormationType', 'equals', resourceType).only();
         const service = db.incoming('hasResource', resource).only().entity;
 
-        // Allocate new dimension set, connect to resource & service and fill with dimensions
-        const dimensions = group.dimensions.map((d) => ({
-          name: d.dimensionName,
-          value: d.dimensionValue,
-        }));
-        // Temporary name: Dim1PerDim2
-        const dimsetName = dimensions.map((d) => d.name).join('Per');
+        // Allocate new dimension set, connect to resource & service
         const dimensionSet = db.findOrAllocate(
           'dimensionSet',
           'dedupKey',
@@ -77,7 +86,7 @@ export function importCannedMetrics(
           db.link('resourceHasMetric', resource, metric);
           db.link('serviceHasMetric', service, metric);
         }
-      } catch (unused: any) {
+      } catch {
         skippedResources.add(group.resourceType);
       }
     }

--- a/packages/@aws-cdk/service-spec-importers/src/types/cloudwatch-console-service-directory/CloudWatchConsoleServiceDirectory.ts
+++ b/packages/@aws-cdk/service-spec-importers/src/types/cloudwatch-console-service-directory/CloudWatchConsoleServiceDirectory.ts
@@ -10,6 +10,16 @@
 
 export type CloudWatchConsoleServiceDirectory = ServiceDirectoryEntry[];
 
+/**
+ * Human-readable names for dimension sets, keyed by CloudWatch namespace and dimension key.
+ */
+export interface DimensionSetNames {
+  [namespace: string]: {
+    /** Alphabetically sorted, comma-separated dimension names (e.g. 'InstanceId,VolumeId') */
+    [dimensionKey: string]: string;
+  };
+}
+
 export interface ServiceDirectoryEntry {
   readonly id: string;
   readonly dashboard?: string;

--- a/packages/@aws-cdk/service-spec-importers/test/canned-metrics.test.ts
+++ b/packages/@aws-cdk/service-spec-importers/test/canned-metrics.test.ts
@@ -62,6 +62,7 @@ test('adds corresponding metrics to the database', () => {
       },
     ],
     report,
+    { 'AWS/Some': { 'Asgard,Astral Plane,Microverse': 'Microverse' } },
   );
 
   // THEN
@@ -121,6 +122,7 @@ test('deduplicates dimension sets with equal dimensions within a service', () =>
       },
     ],
     report,
+    { 'AWS/Some': { LoadBalancer: 'LoadBalancer' } },
   );
 
   // THEN exactly one dimensionSet exists and both metrics link to it
@@ -177,6 +179,10 @@ test('does not deduplicate equal dimension sets across different services', () =
       },
     ],
     report,
+    {
+      'AWS/Some': { LoadBalancer: 'LoadBalancer' },
+      'AWS/Other': { LoadBalancer: 'LoadBalancer' },
+    },
   );
 
   // THEN each service gets its own dimensionSet (salt = service.name)
@@ -216,10 +222,34 @@ test('does not add metrics for unknown resources', () => {
       },
     ],
     report,
+    { 'AWS/Some': { 'Asgard,Astral Plane,Microverse': 'Microverse' } },
   );
 
   // THEN
   const res = db.lookup('resource', 'cloudFormationType', 'equals', 'AWS::Some::Type')[0];
   const metricEdges = db.follow('resourceHasMetric', res);
   expect(metricEdges.length).toEqual(0);
+});
+
+test('throws an error when dimension set name is not found', () => {
+  expect(() =>
+    importCannedMetrics(
+      db,
+      [
+        {
+          id: 'AWS::Some',
+          metricTemplates: [
+            {
+              resourceType: 'AWS::Some::Type',
+              namespace: 'AWS/Some',
+              dimensions: [{ dimensionName: 'UnknownDim' }],
+              metrics: [{ id: 'M', name: 'M', defaultStat: 'Sum' }],
+            },
+          ],
+        },
+      ],
+      report,
+      { 'AWS/Some': { SomethingElse: 'SomethingElse' } },
+    ),
+  ).toThrow("No dimension set name found for namespace 'AWS/Some', dimensions 'UnknownDim'");
 });

--- a/sources/CloudWatchConsoleServiceDirectory/README.md
+++ b/sources/CloudWatchConsoleServiceDirectory/README.md
@@ -6,6 +6,11 @@ This source of AWS metrics is kindly provided to us by the CloudWatch Explorer t
 
 The source file is generated using the `update-service-directory.sh` script.
 
+## Files
+
+- `CloudWatchConsoleServiceDirectory.json` — the metric templates source data
+- `dimension-sets-names.json` — human-readable names for dimension sets, keyed by namespace and alphabetically sorted dimension names. Must be updated when new dimension sets are added to the service directory.
+
 ## Instructions
 
 Only `metricTemplates` are currently used.

--- a/sources/CloudWatchConsoleServiceDirectory/dimension-sets-names.json
+++ b/sources/CloudWatchConsoleServiceDirectory/dimension-sets-names.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36b47d3d3e223d1ad6be6a8e815fb1d87db8d62afc5aa7bce5423330235ed5b5
+size 10014


### PR DESCRIPTION
The canned metrics importer previously generated dimension set names by joining dimension names with "Per" (e.g. `InstanceIdPerVolumeId`). This was marked as "Temporary name" in the code. This PR replaces that with a curated `dimension-sets-names.json` mapping that provides human-readable names (e.g. `Volume`, `LoadBalancer`, `TargetGroupPerLoadBalancer`).

### Changes

- Add `sources/CloudWatchConsoleServiceDirectory/dimension-sets-names.json` — a mapping of `{ namespace → sorted dimension key → human name }`
- Add `DimensionSetNames` interface to the CloudWatch console service directory types
- `importCannedMetrics` now takes a `DimensionSetNames` parameter and looks up names by namespace + alphabetically sorted, comma-separated dimension names
- Throws an error if a dimension set name is missing from the mapping (empty dimension sets default to `"Account"`)
- `DatabaseBuilder.importCannedMetrics` now takes a directory path instead of a file path, and loads both `CloudWatchConsoleServiceDirectory.json` and `dimension-sets-names.json` from it
- Updated existing tests to pass dimension set names, added a test for the missing-name error case

### Why throw instead of report?

Missing dimension set names indicate a data gap that should be fixed before shipping — once set, these cannot be changed for backward compatibility reasons. This ensures `dimension-sets-names.json` stays in sync with the service directory.