### PR TITLE
fix(projen): move github context out of diff-db shell step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,6 +174,8 @@ jobs:
         if: steps.diff-db.outputs.diff-result
         env:
           DIFF_LIMIT: "200000"
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
         run: |-
           if [ $(wc -c < DIFF) -gt $DIFF_LIMIT ]; then
             echo "> [!WARNING]" >> PR.md
@@ -181,7 +183,7 @@ jobs:
             echo "" >> PR.md
           fi
           echo '**@aws-cdk/aws-service-spec**: Model database diff detected' >> PR.md
-          echo "[📁 Download full diff](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> PR.md
+          echo "[📁 Download full diff](https://github.com/${REPOSITORY}/actions/runs/${RUN_ID})" >> PR.md
           echo '```' >> PR.md
           head -c $DIFF_LIMIT DIFF >> PR.md
           if [ $(wc -c < DIFF) -gt $DIFF_LIMIT ]; then

--- a/projenrc/diff-db.ts
+++ b/projenrc/diff-db.ts
@@ -139,6 +139,11 @@ export class DiffDb extends pj.Component {
           if: 'steps.diff-db.outputs.diff-result',
           env: {
             DIFF_LIMIT: String(200_000), // @see https://github.com/dead-claudia/github-limits?tab=readme-ov-file#pr-body
+            // Pass GitHub context through env vars instead of interpolating
+            // `${{ ... }}` expressions directly into the shell script (flagged by
+            // cdklabs-projen-project-types' CheckGhaExpressions).
+            REPOSITORY: '${{ github.repository }}',
+            RUN_ID: '${{ github.run_id }}',
           },
           run: [
             'if [ $(wc -c < DIFF) -gt $DIFF_LIMIT ]; then',
@@ -147,7 +152,7 @@ export class DiffDb extends pj.Component {
             '  echo "" >> PR.md',
             'fi',
             `echo '**${this.serviceSpec.name}**: Model database diff detected' >> PR.md`,
-            'echo "[📁 Download full diff](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> PR.md',
+            'echo "[📁 Download full diff](https://github.com/${REPOSITORY}/actions/runs/${RUN_ID})" >> PR.md',
             "echo '```' >> PR.md",
             'head -c $DIFF_LIMIT DIFF >> PR.md',
             'if [ $(wc -c < DIFF) -gt $DIFF_LIMIT ]; then',


### PR DESCRIPTION
## Problem

The scheduled `upgrade` workflow has been failing at `yarn projen upgrade` (e.g. [run 30317119294](https://github.com/cdklabs/awscdk-service-spec/actions/runs/30317119294)). The upgrade bumps `cdklabs-projen-project-types` to `0.6.7`, whose tightened `CheckGhaExpressions` rule then rejects the project during re-synth:

```
Error: Found dangerous expressions in workflow shell steps. Put these in
environment variables and reference them instead. DO NOT FORGET TO QUOTE THEM!
- wf build: job diff-db.10: github.repository
    at CheckGhaExpressions.postSynthesize (.../check-gha-expressions.ts:25)
```

The `diff-db` job's **Create PR.md** step (in `projenrc/diff-db.ts`) interpolated `${{ github.repository }}` / `${{ github.run_id }}` directly into a `run:` shell script.

## Fix

Pass those GitHub context values through `REPOSITORY` / `RUN_ID` step-level `env:` variables and reference them as quoted shell variables in the script. No behavioral change to the generated PR.md link.

## Verification

- `yarn projen` passes on current deps.
- `yarn projen` also passes after bumping `cdklabs-projen-project-types` to `^0.6.7` (the version that was failing), confirming the `CheckGhaExpressions` error is resolved and the scheduled upgrade will no longer be blocked.